### PR TITLE
New functions for unsupported endpoints + some modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .pytest_cache
 .DS_Store
 NOTES.md
+test.py

--- a/elevenlabs/api/history.py
+++ b/elevenlabs/api/history.py
@@ -57,6 +57,9 @@ class HistoryItem(API):
         if self._audio is None:
             self._audio = API.get(url).content
         return self._audio
+    
+    def delete(self):
+        API.delete(f"{api_base_url_v1}/history/{self.history_item_id}")
 
 
 class History(Listable, API):

--- a/elevenlabs/api/user.py
+++ b/elevenlabs/api/user.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
+from typing import Optional
 
 from .base import API, api_base_url_v1
 
-
 class Subscription(API):
+    tier: str
     character_count: int
     character_limit: int
+    can_extend_character_limit: bool
+    allowed_to_extend_character_limit: bool
+    next_character_count_reset_unix: int
+    voice_limit: int
+    professional_voice_limit: int
+    can_extend_voice_limit: bool
+    can_use_instant_voice_cloning: bool
+    can_use_professional_voice_cloning: bool
+    currency: Optional[str]
     status: str
 
 
@@ -16,4 +26,9 @@ class User(API):
     def from_api(cls) -> User:
         url = f"{api_base_url_v1}/user"
         response = cls.get(url).json()
-        return cls(**response)
+        return cls(subscription=Subscription(**response.get("subscription", {})))
+    
+    def get_subscription(cls):
+        url = f"{api_base_url_v1}/user/subscription"
+        response = API.get(url).json()
+        return Subscription(**response)

--- a/elevenlabs/api/user.py
+++ b/elevenlabs/api/user.py
@@ -18,6 +18,12 @@ class Subscription(API):
     currency: Optional[str]
     status: str
 
+    @classmethod
+    def from_api(cls) -> Subscription:
+        url = f"{api_base_url_v1}/user/subscription"
+        response = API.get(url).json()
+        return cls(**response)
+
 
 class User(API):
     subscription: Subscription
@@ -26,9 +32,4 @@ class User(API):
     def from_api(cls) -> User:
         url = f"{api_base_url_v1}/user"
         response = cls.get(url).json()
-        return cls(subscription=Subscription(**response.get("subscription", {})))
-    
-    def get_subscription(cls):
-        url = f"{api_base_url_v1}/user/subscription"
-        response = API.get(url).json()
-        return Subscription(**response)
+        return cls(**response)

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -133,36 +133,35 @@ class Voice(API):
     def computed_settings(cls, v: VoiceSettings, values) -> VoiceSettings:
         url = f"{api_base_url_v1}/voices/{values['voice_id']}/settings"
         return v if v else VoiceSettings(**API.get(url).json())
+    
+    @classmethod
+    def default_settings(cls):
+        url = f"{api_base_url_v1}/voices/settings/default"
+        return VoiceSettings(**API.get(url).json())
 
     def delete(self):
         API.delete(f"{api_base_url_v1}/voices/{self.voice_id}")
 
-    def edit_settings(self, stability: float, similarity_boost: float):
+    # def edit_settings(self, stability: float, similarity_boost: float):
+    def edit_settings(self, voice_settings: VoiceSettings):
         url = f"{api_base_url_v1}/voices/{self.voice_id}/settings/edit"
         json = {
-            "stability": stability,
-            "similarity_boost": similarity_boost,
+            "stability": voice_settings.stability,
+            "similarity_boost": voice_settings.similarity_boost,
         }
         API.post(url, json=json)
-
-    def get_settings(self):
-        url = f"{api_base_url_v1}/voices/{self.voice_id}/settings"
-        return VoiceSettings(**API.get(url).json())
     
-    def get_info(self):
-        url = f"{api_base_url_v1}/voices/{self.voice_id}"
-        return Voice(**API.get(url).json())
-    
-    def edit(self, name: str, labels: Optional[str] = None, description: Optional[str] = None):
-        url = f"{api_base_url_v1}/voices/{self.voice_id}/edit"
-        data = {
-            "name": name,
-        }
-        if labels: # Putting it as None will overwrite the labels
-            data["labels"] = labels
-        if description: # Putting it as None will overwrite the description
-            data["description"] = description
-        API.post(url, data=data)
+    def edit(
+        cls,
+        name: Optional[str] = None,
+        labels: Optional[str] = None,
+        description: Optional[str] = None
+    ):
+        url = f"{api_base_url_v1}/voices/{cls.voice_id}/edit"
+        cls.name = name or cls.name
+        cls.labels = labels or cls.labels
+        cls.description = description or cls.description
+        API.post(url, data=dict(name=cls.name, labels=cls.labels, description=cls.description))
 
 class Voices(Listable, API):
     voices: List[Voice]
@@ -172,11 +171,6 @@ class Voices(Listable, API):
         url = f"{api_base_url_v1}/voices"
         response = API.get(url).json()
         return cls(**response)
-    
-    @classmethod
-    def default_settings(cls):
-        url = f"{api_base_url_v1}/voices/settings/default"
-        return VoiceSettings(**API.get(url).json())
 
     def add_clone(self, voice_clone: VoiceClone) -> Voice:
         pass

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -142,26 +142,21 @@ class Voice(API):
     def delete(self):
         API.delete(f"{api_base_url_v1}/voices/{self.voice_id}")
 
-    # def edit_settings(self, stability: float, similarity_boost: float):
     def edit_settings(self, voice_settings: VoiceSettings):
         url = f"{api_base_url_v1}/voices/{self.voice_id}/settings/edit"
-        json = {
-            "stability": voice_settings.stability,
-            "similarity_boost": voice_settings.similarity_boost,
-        }
-        API.post(url, json=json)
+        API.post(url, json=voice_settings.dict())
     
     def edit(
-        cls,
+        self,
         name: Optional[str] = None,
         labels: Optional[str] = None,
         description: Optional[str] = None
     ):
-        url = f"{api_base_url_v1}/voices/{cls.voice_id}/edit"
-        cls.name = name or cls.name
-        cls.labels = labels or cls.labels
-        cls.description = description or cls.description
-        API.post(url, data=dict(name=cls.name, labels=cls.labels, description=cls.description))
+        url = f"{api_base_url_v1}/voices/{self.voice_id}/edit"
+        self.name = name or self.name
+        self.labels = labels or self.labels
+        self.description = description or self.description
+        API.post(url, data=dict(name=self.name, labels=self.labels, description=self.description))
 
 class Voices(Listable, API):
     voices: List[Voice]

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -137,6 +137,32 @@ class Voice(API):
     def delete(self):
         API.delete(f"{api_base_url_v1}/voices/{self.voice_id}")
 
+    def edit_settings(self, stability: float, similarity_boost: float):
+        url = f"{api_base_url_v1}/voices/{self.voice_id}/settings/edit"
+        json = {
+            "stability": stability,
+            "similarity_boost": similarity_boost,
+        }
+        API.post(url, json=json)
+
+    def get_settings(self):
+        url = f"{api_base_url_v1}/voices/{self.voice_id}/settings"
+        return VoiceSettings(**API.get(url).json())
+    
+    def get_info(self):
+        url = f"{api_base_url_v1}/voices/{self.voice_id}"
+        return Voice(**API.get(url).json())
+    
+    def edit(self, name: str, labels: Optional[str] = None, description: Optional[str] = None):
+        url = f"{api_base_url_v1}/voices/{self.voice_id}/edit"
+        data = {
+            "name": name,
+        }
+        if labels: # Putting it as None will overwrite the labels
+            data["labels"] = labels
+        if description: # Putting it as None will overwrite the description
+            data["description"] = description
+        API.post(url, data=data)
 
 class Voices(Listable, API):
     voices: List[Voice]
@@ -146,6 +172,11 @@ class Voices(Listable, API):
         url = f"{api_base_url_v1}/voices"
         response = API.get(url).json()
         return cls(**response)
+    
+    @classmethod
+    def default_settings(cls):
+        url = f"{api_base_url_v1}/voices/settings/default"
+        return VoiceSettings(**API.get(url).json())
 
     def add_clone(self, voice_clone: VoiceClone) -> Voice:
         pass

--- a/elevenlabs/simple.py
+++ b/elevenlabs/simple.py
@@ -81,6 +81,10 @@ def voices() -> Voices:
     VOICES_CACHE = Voices.from_api(api_key) if api_key else VOICES_CACHE
     return VOICES_CACHE
 
+def default_settings() -> VoiceSettings:
+    """Returns the default voice settings"""
+    return Voices.default_settings()
+
 
 def clone(**kwargs) -> Voice:
     return Voice.from_clone(VoiceClone(**kwargs))

--- a/elevenlabs/simple.py
+++ b/elevenlabs/simple.py
@@ -81,10 +81,6 @@ def voices() -> Voices:
     VOICES_CACHE = Voices.from_api(api_key) if api_key else VOICES_CACHE
     return VOICES_CACHE
 
-def default_settings() -> VoiceSettings:
-    """Returns the default voice settings"""
-    return Voices.default_settings()
-
 
 def clone(**kwargs) -> Voice:
     return Voice.from_clone(VoiceClone(**kwargs))


### PR DESCRIPTION
This PR brings support to multiple endpoints that I noticed were not supported in this wrapper:
1. `/v1/voices/settings/default`
2. `/v1/voices/{voice_id}/settings`
3. `/v1/voices/{voice_id}/settings/edit`
4. `/v1/voices/{voice_id}`
5. `/v1/voices/{voice_id}/edit`
6. `/v1/history/{history_item_id}`
7. `/v1/user/subscription`

I've also modified the following:
1. `Subscription` class: Added new properties.
2. `User` class: the `from_api` function was not working so I fixed it.