### PR TITLE
Add the 'preview_url' parameter to Voice API

### DIFF
--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -92,6 +92,7 @@ class Voice(API):
     samples: Optional[List[VoiceSample]]
     settings: Optional[VoiceSettings]
     design: Optional[VoiceDesign]
+    preview_url: Optional[str]
 
     @classmethod
     def from_id(cls, voice_id: str):


### PR DESCRIPTION
For the application I'm building, I need the `preview_url`. I figured I might just as well create a commit for the official ElevenLabs Python package instead of creating a separate method.

I believe there are more parameters returned by the API that are not covered in the package. Those would be (directly from your API, but I cut out the existing parameters):
```
{
      "fine_tuning": {
        "model_id": null,
        "language": null,
        "is_allowed_to_fine_tune": false,
        "fine_tuning_requested": false,
        "finetuning_state": "not_started",
        "verification_attempts": null,
        "verification_failures": [],
        "verification_attempts_count": 0,
        "slice_ids": null
      },
      "available_for_tiers": [],
      "sharing": null
},
 ```

But those parameters might be for another PR 🙂