### PR TITLE
Fix pydantic model validation

### DIFF
--- a/elevenlabs/api/history.py
+++ b/elevenlabs/api/history.py
@@ -35,7 +35,7 @@ class HistoryItem(API):
     feedback: Optional[FeedbackItem]
     _audio: Optional[bytes] = None
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def computed(cls, values):
         # Compute character count field
         change_from = values["character_count_change_from"]

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -34,7 +34,7 @@ class VoiceClone(API):
     labels: Optional[Dict[str, str]]
     _files_tuple: Optional[List[Tuple]] = None
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def computed_files_tuple(cls, values) -> List[str]:
         files_tuple = []
         for filepath in values["files"]:


### PR DESCRIPTION
The current implementation of `root_validator` for `VoiceClone` class is broken (supposedly the same is true for `HistoryItem`) because the validator is being called even if the prior default field validation failed. In particular, this leads to a very confusing and annoying behaviour when the user passes more than 25 files for voice cloning:
```python
from api import Voice, VoiceClone

Voice.from_clone(VoiceClone(name="dummy", description="dummy", files=["dummy"] * 26))
```
The above code results in the following error which is really obscure and hard to debug:
```
Traceback (most recent call last):
  File "/home/george/code/elevenlabs-python/elevenlabs/test.py", line 5, in <module>
    Voice.from_clone(VoiceClone(name="dummy", description="dummy", files=["dummy"] * 26))
  File "pydantic/main.py", line 339, in pydantic.main.BaseModel.__init__
  File "pydantic/main.py", line 1102, in pydantic.main.validate_model
  File "/home/george/code/elevenlabs-python/elevenlabs/api/voice.py", line 40, in computed_files_tuple
    for filepath in values["files"]:
KeyError: 'files
```
The error happens because the `root_validator` runs on the model with some fields missing due being invalid. This can be fixed with the proposed change according to [the pydantic docs](https://docs.pydantic.dev/latest/usage/validators/#root-validators). After the change the error becomes much more obvious:
```
Traceback (most recent call last):
  File "/home/george/code/elevenlabs-python/elevenlabs/test.py", line 5, in <module>
    Voice.from_clone(VoiceClone(name="dummy", description="dummy", files=["dummy"] * 26))
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for VoiceClone
files
  ensure this value has at most 25 items (type=value_error.list.max_items; limit_value=25)
```