### PR TITLE
added optimize_streaming_latency param

### DIFF
--- a/elevenlabs/api/tts.py
+++ b/elevenlabs/api/tts.py
@@ -21,15 +21,16 @@ class TTS(API):
         response = API.post(url, json=data, api_key=api_key)
         return response.content
 
-    @staticmethod
+   @staticmethod
     def generate_stream(
         text: str,
         voice: Voice,
         model: Model,
         stream_chunk_size: int = 2048,
         api_key: Optional[str] = None,
+        latency: int = 1,
     ) -> Iterator[bytes]:
-        url = f"{api_base_url_v1}/text-to-speech/{voice.voice_id}/stream"
+        url = f"{api_base_url_v1}/text-to-speech/{voice.voice_id}/stream?optimize_streaming_latency={latency}"
         data = dict(
             text=text,
             model_id=model.model_id,

--- a/elevenlabs/simple.py
+++ b/elevenlabs/simple.py
@@ -96,6 +96,7 @@ def generate(
     voice: Union[str, Voice] = VOICES_CACHE[2],  # Bella
     model: Union[str, Model] = "eleven_monolingual_v1",
     stream: bool = False,
+    latency: int = 1,
     stream_chunk_size: int = 2048,
 ) -> Union[bytes, Iterator[bytes]]:
 
@@ -122,7 +123,7 @@ def generate(
 
     if stream:
         return TTS.generate_stream(
-            text, voice, model, stream_chunk_size, api_key=api_key
+            text, voice, model, stream_chunk_size, api_key=api_key, latency=latency
         )  # noqa E501
     else:
         return TTS.generate(text, voice, model, api_key=api_key)


### PR DESCRIPTION
Hey there the Python wrapper did not have access to this URL param, so I added it.

based on this:  https://help.elevenlabs.io/hc/en-us/articles/15726761640721-Can-I-reduce-API-latency-

Tested locally and with `optimize_streaming_latency=3` it's WAAAY faster