### PR TITLE
Added description and labels fields to VoiceDesign

### DIFF
--- a/API.md
+++ b/API.md
@@ -272,7 +272,7 @@ from elevenlabs import Voice, VoiceDesign, Gender, Age, Accent, play
 design = VoiceDesign(
     name='Lexa',
     text="Hello, my name is Lexa. I'm your personal assistant, I can help you with your daily tasks and I can also read you the news.",
-    description="A young british female voice, resembling a secretary. Perfect for the office assistant roles.",
+    description="A young british female voice, resembling a secretary. Perfect for office assistant roles.",
     labels={'accent': 'british', 'gender': 'female', 'age': 'young'},
     gender=Gender.female,
     age=Age.young,

--- a/API.md
+++ b/API.md
@@ -272,6 +272,8 @@ from elevenlabs import Voice, VoiceDesign, Gender, Age, Accent, play
 design = VoiceDesign(
     name='Lexa',
     text="Hello, my name is Lexa. I'm your personal assistant, I can help you with your daily tasks and I can also read you the news.",
+    description="A young british female voice, resembling a secretary. Perfect for the office assistant roles.",
+    labels={'accent': 'british', 'gender': 'female', 'age': 'young'},
     gender=Gender.female,
     age=Age.young,
     accent=Accent.british,

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -68,6 +68,8 @@ class VoiceDesign(API):
     name: str
     text: str = Field(..., min_length=100)
     gender: Gender
+    description: str
+    labels: dict
     age: Age
     accent: Accent
     accent_strength: float = Field(..., gt=0.3, lt=2.0)
@@ -123,7 +125,9 @@ class Voice(API):
         url = f"{api_base_url_v1}/voice-generation/create-voice"
         data = dict(
             voice_name=voice_design.name,
+            voice_description=voice_design.description,
             generated_voice_id=voice_design.generated_voice_id,
+            labels=voice_design.labels,
         )
         response = API.post(url, json=data)
         voice = cls.from_id(voice_id=response.json()["voice_id"])


### PR DESCRIPTION
The server-side requirements for `v1/voice-generation/create-voice` include a description and labels field. The mismatch between the previous setup of `VoiceDesign` and the server-side requirements was causing HTTPError422, Unprocessable Entity.
Updated API.md to match the new design of `VoiceDesign`
closes #54
closes #94 