### PR TITLE
Add support for use_speaker_boost and style voice settings

### DIFF
--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -17,6 +17,8 @@ class UnauthorizedVoiceCloningError(APIError):
 class VoiceSettings(API):
     stability: float = Field(..., ge=0.0, le=1.0)
     similarity_boost: float = Field(..., ge=0.0, le=1.0)
+    style: float = Field(..., ge=0.0, le=1.0)
+    use_speaker_boost: bool = Field(...)
 
 
 class VoiceSample(API):


### PR DESCRIPTION
This PR adds support for the `use_speaker_boost` and `style` voice settings currently only exposed through [the REST API](https://api.elevenlabs.io/docs#/voices/Edit_voice_settings_v1_voices__voice_id__settings_edit_post).  Fixes #95.