### PR TITLE
Add support for passing `latency` to `generate_stream_input` similar to `generate_stream`

### DIFF
--- a/elevenlabs/api/tts.py
+++ b/elevenlabs/api/tts.py
@@ -67,7 +67,7 @@ class TTS(API):
 
     @staticmethod
     def generate_stream_input(
-        text: Iterator[str], voice: Voice, model: Model, api_key: Optional[str] = None
+        text: Iterator[str], voice: Voice, model: Model, api_key: Optional[str] = None, latency: int = 1,
     ) -> Iterator[bytes]:
         BOS = json.dumps(
             dict(
@@ -82,7 +82,7 @@ class TTS(API):
         EOS = json.dumps(dict(text=""))
 
         with connect(
-            f"wss://api.elevenlabs.io/v1/text-to-speech/{voice.voice_id}/stream-input?model_id={model.model_id}",
+            f"wss://api.elevenlabs.io/v1/text-to-speech/{voice.voice_id}/stream-input?model_id={model.model_id}&optimize_streaming_latency={latency}",
             additional_headers={
                 "xi-api-key": api_key or os.environ.get("ELEVEN_API_KEY")
             },

--- a/elevenlabs/simple.py
+++ b/elevenlabs/simple.py
@@ -67,7 +67,7 @@ def generate(
                 text, voice, model, stream_chunk_size, api_key=api_key, latency=latency
             )  # noqa E501
         elif isinstance(text, Iterator):
-            return TTS.generate_stream_input(text, voice, model, api_key=api_key)
+            return TTS.generate_stream_input(text, voice, model, api_key=api_key, latency=latency)
     else:
         assert isinstance(text, str)
         return TTS.generate(text, voice, model, api_key=api_key)


### PR DESCRIPTION
This option was missing from `generate_stream_input`

Thanks!
