### PR TITLE
Fix API error handling (list response + defaults)

### DIFF
--- a/elevenlabs/api/base.py
+++ b/elevenlabs/api/base.py
@@ -48,8 +48,12 @@ class API(BaseModel):
         if "detail" in error:
             detail = error["detail"]
             if isinstance(error, dict):
-                message = detail.get("message", "")
-                status = detail.get("status", "")
+                if isinstance(detail, list):
+                    message = ', '.join([f"{err.get('loc')[-1]}: {err.get('msg', '')}" for err in detail])
+                    status = str(response.status_code)
+                else:
+                    message = detail.get("message", "")
+                    status = detail.get("status", "")
         else:
             message = str(error)
             status = str(response.status_code)

--- a/elevenlabs/api/voice.py
+++ b/elevenlabs/api/voice.py
@@ -18,8 +18,8 @@ class UnauthorizedVoiceCloningError(APIError):
 class VoiceSettings(API):
     stability: float = Field(..., ge=0.0, le=1.0)
     similarity_boost: float = Field(..., ge=0.0, le=1.0)
-    style: Optional[float] = Field(None, ge=0.0, le=1.0)
-    use_speaker_boost: Optional[bool] = None
+    style: Optional[float] = Field(0.0, ge=0.0, le=1.0)
+    use_speaker_boost: Optional[bool] = False
 
     @classmethod
     def from_voice_id(cls, voice_id: str) -> VoiceSettings:


### PR DESCRIPTION
Ran into some unhelpful exceptions when handling API errors: lists weren't handled as error responses, and the defaults for `VoiceSettings` caused those errors. 

Initially, it showed:

```
status = detail.get("status", "")
         ^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

Now it shows:

```
elevenlabs.api.error.APIError: style: none is not an allowed value, use_speaker_boost: none is not an allowed value
```

Tests pass locally. Hope it helps!

