### PR TITLE
Fix history iteration bug and modify test

### DIFF
--- a/elevenlabs/api/history.py
+++ b/elevenlabs/api/history.py
@@ -99,5 +99,5 @@ class History(Listable, API):
             self.has_more = history_next.has_more
             self.last_history_item_id = history_next.last_history_item_id
 
-            for item in self.history:
+            for item in history_next:
                 yield item

--- a/elevenlabs/tests/api/test_history.py
+++ b/elevenlabs/tests/api/test_history.py
@@ -10,10 +10,15 @@ def test_history():
     assert isinstance(history, History)
 
     # Test that we can iterate over multiple pages lazily
+    history_item_ids = []
     it = iter(history)
     for i in range(page_size * 3):
         try:
-            assert isinstance(next(it), HistoryItem)
+            item = next(it)
+            assert isinstance(item, HistoryItem)
+            # Assert no duplicate history_item_ids
+            assert item.history_item_id not in history_item_ids
+            history_item_ids.append(item.history_item_id)
         except StopIteration:
             warnings.warn("Warning: not enough history items to test multiple pages.")
             break


### PR DESCRIPTION
The current implementation of the `History` iterator has a bug that causes it to return duplicate `HistoryItem`s if there are more than one page of results.

For example, assume that your history contains 10 items, with IDs `1` - `10`. A call to `History.from_api(page_size=5)` will return a `History` object whose iterator will return the following sequence of item IDs:

`[1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`

Note that it returns the first page's items twice. This will continue to occur with each subsequent page with the repeated element list getting longer each time.

This pull request includes a simple fix to the `History` iterator and a modification to the `test_history` unit test that will fail if duplicate items are returned from the `History` iterator.