### PR TITLE
Clearer error message when text isn't an iterator or string (e.g it's…

### DIFF
--- a/elevenlabs/simple.py
+++ b/elevenlabs/simple.py
@@ -61,6 +61,7 @@ def generate(
 
     assert isinstance(voice, Voice)
     assert isinstance(model, Model)
+    assert isinstance(text, str) or isinstance(text, Iterator)
 
     if stream:
         if isinstance(text, str):


### PR DESCRIPTION
… a coroutine)