### PR TITLE
(fix): move repository url field into tool.poetry namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = []
 keywords = []
 license = "MIT"
+repository = 'https://github.com/elevenlabs/elevenlabs-python'
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
@@ -27,9 +28,6 @@ classifiers = [
 packages = [
     { include = "elevenlabs", from = "src"}
 ]
-
-[project.urls]
-Repository = 'https://github.com/elevenlabs/elevenlabs-python'
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This patch updates pyproject.toml to allow tools like uv to install this package from source.

It seems that having `project.urls` along with `tool.poetry` is not spec compliant, pip itself seems to be more permissive but uv refuses to install this project from source. See [astral-sh/uv issue #6419](https://github.com/astral-sh/uv/issues/6419) for more details on the toml stuff.

As an fyi, using project.urls.repository field seems to have no effect on the [PyPI listing](https://pypi.org/project/elevenlabs/1.7.0/) of the package: 

If needed, I can open this up as an issue, as this repository is codegen'ed.