### PR TITLE
Add chunk_size to (a)iter_bytes

### DIFF
--- a/src/elevenlabs/text_to_speech/client.py
+++ b/src/elevenlabs/text_to_speech/client.py
@@ -150,7 +150,7 @@ class TextToSpeechClient:
         ) as _response:
             try:
                 if 200 <= _response.status_code < 300:
-                    for _chunk in _response.iter_bytes():
+                    for _chunk in _response.iter_bytes(chunk_size=1024):
                         yield _chunk
                     return
                 _response.read()
@@ -436,7 +436,7 @@ class TextToSpeechClient:
         ) as _response:
             try:
                 if 200 <= _response.status_code < 300:
-                    for _chunk in _response.iter_bytes():
+                    for _chunk in _response.iter_bytes(chunk_size=1024):  # 1 MB
                         yield _chunk
                     return
                 _response.read()
@@ -728,7 +728,7 @@ class AsyncTextToSpeechClient:
         ) as _response:
             try:
                 if 200 <= _response.status_code < 300:
-                    async for _chunk in _response.aiter_bytes():
+                    async for _chunk in _response.aiter_bytes(chunk_size=1024):  # 1 MB
                         yield _chunk
                     return
                 await _response.aread()
@@ -1030,7 +1030,7 @@ class AsyncTextToSpeechClient:
         ) as _response:
             try:
                 if 200 <= _response.status_code < 300:
-                    async for _chunk in _response.aiter_bytes():
+                    async for _chunk in _response.aiter_bytes(chunk_size=1024):  # 1 MB
                         yield _chunk
                     return
                 await _response.aread()

--- a/src/elevenlabs/text_to_speech/client.py
+++ b/src/elevenlabs/text_to_speech/client.py
@@ -150,7 +150,7 @@ class TextToSpeechClient:
         ) as _response:
             try:
                 if 200 <= _response.status_code < 300:
-                    for _chunk in _response.iter_bytes(chunk_size=1024):
+                    for _chunk in _response.iter_bytes(chunk_size=1024): # 1 MB
                         yield _chunk
                     return
                 _response.read()


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/elevenlabs-python/issues/366

The issue is because the server now supports gzip responses and the client is allowing gzip as an encoding. This is a problem because people might want to stream the audio and if the chunk is too small or an odd number, it's not a valid audio chunk