### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Create a bug report for the ElevenLabs Python SDK
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug with the **ElevenLabs Python SDK**. Please fill out the sections below to help us understand and resolve the issue.
+
+        **Note:** The ElevenLabs Python SDK is **auto-generated from [Fern](https://www.buildwithfern.com/)** and is a wrapper around our OpenAPI specification. Direct modifications to the SDK code may be overwritten in future releases.
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        **Describe the bug in detail and provide clear steps to reproduce it.**
+
+        Include information such as:
+        - What you were trying to achieve.
+        - What happened instead.
+        - Any relevant parameters or configurations.
+      placeholder: |
+        **Steps to reproduce:**
+        1. ...
+        2. ...
+
+        **Expected behavior:**
+
+        **Actual behavior:**
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code example
+      description: Provide an example code snippet that has the problem
+      placeholder: |
+        ```python
+        from elevenlabs import generate, play
+
+        # Your code here
+        ```
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context or screenshots about the problem here.
+      placeholder: |
+        - Related issues:
+        - Possible workaround:
+        - Logs
+        - ...

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -32,7 +32,7 @@ body:
   - type: textarea
     attributes:
       label: Code example
-      description: Provide an example code snippet that has the problem
+      description: Provide an example code snippet that has the problem (Make sure to **NOT** upload or expose your API key).
       placeholder: |
         ```python
         from elevenlabs import generate, play

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Propose a new feature for the ElevenLabs Python SDK
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to propose a new feature for the **ElevenLabs Python SDK**. Please provide detailed information below to help us understand your proposal.
+
+        **Note:** The ElevenLabs Python SDK is **auto-generated from [Fern](https://fern.dev)** and is a wrapper around our OpenAPI specification. Additions made directly to the SDK code may be overwritten in future releases. We recommend opening an issue to discuss your feature request so we can explore how it fits into our API.
+
+  - type: textarea
+    attributes:
+      label: Feature Description
+      description: A detailed description of the feature you are proposing for the SDK. Include information such as the problem it solves, how it would work, and any relevant APIs or modules it would involve.
+      placeholder: |
+        **Feature description:**
+
+        - What is the feature?
+        - What problem does it solve?
+        - How do you envision it working?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Use Case
+      description: Provide one or more use cases where this feature would be beneficial.
+      placeholder: |
+        **Use case:**
+
+        - Describe a scenario where this feature would be useful.
+  - type: textarea
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      placeholder: |
+        **Alternatives considered:**
+
+        - Other ways to solve the problem?
+        - Why do these alternatives fall short?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Any extra information, references, or screenshots that might help us understand your feature request.
+      placeholder: |
+        - Related issues or discussions:
+        - Relevant links:
+        - Screenshots or mockups:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question (Discord)
+    url: https://discord.com/invite/elevenlabs
+    about: Please ask questions in our discussions forum.


### PR DESCRIPTION
Adds structured templates to submit either a feedback request/bug fix, new issues are now automatically tagged on creation.

TODO: Make sure people do not use issues for security incident reports.