### PR TITLE
Remove pyproject.toml + poetry.lock from .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -6,9 +6,6 @@ src/elevenlabs/conversational_ai/default_audio_interface.py
 src/elevenlabs/play.py
 src/elevenlabs/realtime_tts.py
 
-pyproject.toml
-poetry.lock
-
 .github/workflows/ci.yml
 .github/workflows/tests.yml
 


### PR DESCRIPTION
Need to have that generated, should support the features we need for the manually added stuff in #399 (and #389). But need to merge this first before being able to test the generated SDK preview.