### PR TITLE
fix: stream with timestamp now returns a value

### DIFF
--- a/src/elevenlabs/text_to_speech/client.py
+++ b/src/elevenlabs/text_to_speech/client.py
@@ -538,7 +538,7 @@ class TextToSpeechClient:
             BodyTextToSpeechStreamingWithTimestampsV1TextToSpeechVoiceIdStreamWithTimestampsPostApplyTextNormalization
         ] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
-    ) -> None:
+    ) -> typing.Optional[typing.Any]:
         """
         Converts text into speech using a voice of your choice and returns a stream of JSONs containing audio as a base64 encoded string together with information on when which character was spoken.
 
@@ -647,7 +647,13 @@ class TextToSpeechClient:
         )
         try:
             if 200 <= _response.status_code < 300:
-                return
+                return typing.cast(
+                    typing.Optional[typing.Any],
+                    construct_type(
+                        type_=typing.Optional[typing.Any],  # type: ignore
+                        object_=_response.json(),
+                    ),
+                )
             if _response.status_code == 422:
                 raise UnprocessableEntityError(
                     typing.cast(


### PR DESCRIPTION
WIP - ⚠️ don't merge

# What
Fixed #396 - TextToSpeechClient.stream_with_timestamps does not return or yield response

# Why
I believe it was simply forgotten in the original implementation

# 🎩 Tophatting
Tested that indeed when calling this function - we are receiving back response (See screenshot)

# Design Alternatives
This function is called `stream` - but there isn't any stream - it receive a single text - perhaps think about renaming it / allowing both `text` / `stream`.

p.s I've noticed that your JS library has the same bug of not returning any value from that function.

# Screenshots

![Screenshot 2024-12-03 at 8 59 36](https://github.com/user-attachments/assets/5cda8759-8276-4470-b06f-9cd7699fd3b7)
