### PR TITLE
Update get_signed_url for conversation.py

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -229,5 +229,5 @@ class Conversation:
         return f"{base_ws_url}/v1/convai/conversation?agent_id={self.agent_id}"
 
     def _get_signed_url(self):
-        response = self.client.get_signed_url(agent_id=self.agent_id)
+        response = self.client.conversational_ai.get_signed_url(agent_id=self.agent_id)
         return response.signed_url


### PR DESCRIPTION
Was running into an error when using the Python [convAI example code](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/conversational-ai/python): AttributeError: 'ElevenLabs' object has no attribute 'get_signed_url'  

Bug reported by user: https://github.com/elevenlabs/elevenlabs-python/issues/413 

This change seems to fix it when tested locally. 