### PR TITLE
fix: move class-level attributes to instance-level in Conversation class

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -73,10 +73,10 @@ class Conversation:
     callback_user_transcript: Optional[Callable[[str], None]]
     callback_latency_measurement: Optional[Callable[[int], None]]
 
-    _thread: Optional[threading.Thread] = None
+    _thread: Optional[threading.Thread]
     _should_stop: threading.Event
-    _conversation_id: Optional[str] = None
-    _last_interrupt_id: int = 0
+    _conversation_id: Optional[str]
+    _last_interrupt_id: int
 
     def __init__(
         self,
@@ -119,7 +119,11 @@ class Conversation:
         self.callback_agent_response_correction = callback_agent_response_correction
         self.callback_user_transcript = callback_user_transcript
         self.callback_latency_measurement = callback_latency_measurement
+
+        self._thread = None
         self._should_stop = threading.Event()
+        self._conversation_id = None
+        self._last_interrupt_id = 0
 
     def start_session(self):
         """Starts the conversation session.


### PR DESCRIPTION
Fixes #417 

Why:
Class-level attributes persisted state between sessions. Making them instance-level ensures each session starts fresh.

What:
Moved `_thread`, `_should_stop`, `_conversation_id`, and `_last_interrupt_id` from class-level to instance-level within the __init__ method.

Note: This pull request is a proof of concept, demonstrating how moving class-level attributes to instance-level resolves the session interference issue. I understand this can’t be merged directly due to the code generation process.