### PR TITLE
pyproject.toml: Add Homepage and Issues URLs, bump Python versions to currently supported ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ packages = [
 
 [project.urls]
 Homepage = "https://github.com/elevenlabs/elevenlabs-python"
-Repository = "https://github.com/elevenlabs/elevenlabs-python"
+Repository = "https://github.com/elevenlabs/elevenlabs-python.git"
 Issues = "https://github.com/elevenlabs/elevenlabs-python/issues"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Operating System :: POSIX",
     "Operating System :: MacOS",
@@ -29,10 +29,12 @@ packages = [
 ]
 
 [project.urls]
-Repository = 'https://github.com/elevenlabs/elevenlabs-python'
+Homepage = "https://github.com/elevenlabs/elevenlabs-python"
+Repository = "https://github.com/elevenlabs/elevenlabs-python"
+Issues = "https://github.com/elevenlabs/elevenlabs-python/issues"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 httpx = ">=0.21.2"
 pyaudio = { version = ">=0.2.14", optional = true}
 pydantic = ">= 1.9.2"


### PR DESCRIPTION
Drops 3.8 and sets 3.9 as minimum, explicitly adds support for 3.13 as according to the current upstream Support status - https://devguide.python.org/versions/

Adds Homepage and Issues links so that one can click-through them from PyPI website.

Fixes Repository to point to a .git repo as per https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#a-full-example