### PR TITLE
fix: add dynamic variables support to conversation configuration

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -169,9 +169,11 @@ class ConversationConfig:
         self,
         extra_body: Optional[dict] = None,
         conversation_config_override: Optional[dict] = None,
+        dynamic_variables: Optional[dict] = None,
     ):
         self.extra_body = extra_body or {}
         self.conversation_config_override = conversation_config_override or {}
+        self.dynamic_variables = dynamic_variables or {}
 
 
 class Conversation:
@@ -276,6 +278,7 @@ class Conversation:
                         "type": "conversation_initiation_client_data",
                         "custom_llm_extra_body": self.config.extra_body,
                         "conversation_config_override": self.config.conversation_config_override,
+                        "dynamic_variables": self.config.dynamic_variables,
                     }
                 )
             )

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -130,6 +130,7 @@ def test_conversation_with_dynamic_variables():
     # Setup the conversation
     conversation = Conversation(
         client=mock_client,
+        config=config,
         agent_id=TEST_AGENT_ID,
         requires_auth=False,
         audio_interface=MockAudioInterface(),


### PR DESCRIPTION
python conversational AI SDK doesnt currently support passing dynamic-variables, this simple PR fixes it. 
verified by running locally