### PR TITLE
fix: fetch generated voice id and add to response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 __pycache__/
 poetry.toml
 .ruff_cache/
+env/


### PR DESCRIPTION
currently we only return a bytes iterator with no reference to the voice id generated.
now return a tuple of the id string and then a bytes iterator, so sdk users can unpack and use as needed

fixes #345 
