### PR TITLE
Fix: Error receiving message & Error sending user audio chunk sent 1009 (message too big)

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -272,7 +272,7 @@ class Conversation:
         return self._conversation_id
 
     def _run(self, ws_url: str):
-        with connect(ws_url) as ws:
+        with connect(ws_url, max_size=16 * 1024 * 1024) as ws:
             ws.send(
                 json.dumps(
                     {


### PR DESCRIPTION
Sometimes using the ConversationalAI [demo](https://github.com/elevenlabs/elevenlabs-examples/blob/main/examples/conversational-ai/python/convai/demo.py) throwing exceptions like:
- `Error receiving message: sent 1009 (message too big) frame with 1254313 bytes exceeds limit of 1048576 bytes; no close frame received`
- `Error sending user audio chunk: sent 1009 (message too big) frame with 1254313 bytes exceeds limit of 1048576 bytes; no close frame received`

Seems current ws message limit is too low for some provided sound answers. This fix should fits long response requirements.