### PR TITLE
Fix: Update Conversation WSS URL Construction to Use Latest SyncClientWrapper Implementation

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -370,7 +370,7 @@ class Conversation:
             pass  # Ignore all other message types.
 
     def _get_wss_url(self):
-        base_url = self.client._client_wrapper._base_url
+        base_url = self.client._client_wrapper.get_environment().base
         # Replace http(s) with ws(s).
         base_ws_url = base_url.replace("http", "ws", 1)  # First occurrence only.
         return f"{base_ws_url}/v1/convai/conversation?agent_id={self.agent_id}"

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -163,3 +163,33 @@ def test_conversation_with_dynamic_variables():
     mock_ws.send.assert_any_call(json.dumps(expected_init_message))
     agent_response_callback.assert_called_once_with("Hello there!")
     assert conversation._conversation_id == TEST_CONVERSATION_ID
+
+def test_wss_url_construction():
+    
+    mock_client = MagicMock()
+
+    # Create a mock for _client_wrapper
+    mock_client_wrapper = MagicMock()
+    mock_client._client_wrapper = mock_client_wrapper
+
+    # Create a mock environment with a real string for 'base'
+    mock_environment = MagicMock()
+    mock_environment.base = "https://api.elevenlabs.io"
+    mock_client_wrapper.get_environment.return_value = mock_environment
+
+    # Create a Conversation instance
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=MockAudioInterface(),
+    )
+
+    # HTTPS should become WSS
+    wss_url = conversation._get_wss_url()
+    assert wss_url == "wss://api.elevenlabs.io/v1/convai/conversation?agent_id=test_agent"
+
+    # Switch mock to an HTTP URL
+    mock_environment.base = "http://api.elevenlabs.io"
+    wss_url = conversation._get_wss_url()
+    assert wss_url == "ws://api.elevenlabs.io/v1/convai/conversation?agent_id=test_agent"


### PR DESCRIPTION
Description:
This PR updates the _get_wss_url method in the Conversation object to correctly construct the WebSocket URL when require_auth is set to False. Previously, the URL construction was based on an older version of SyncClientWrapper, which resulted in AttributeError: 'SyncClientWrapper' object has no attribute '_base_url'`

Current version (Old implementation): 
<img width="649" alt="Screenshot 2025-04-14 at 12 01 41 PM" src="https://github.com/user-attachments/assets/9a73393a-85b7-45a5-a41f-c93c638cb3e5" />

Updated Version: 
<img width="620" alt="Screenshot 2025-04-14 at 12 00 48 PM" src="https://github.com/user-attachments/assets/4abd78d9-34b7-4d07-8eec-6e77e8e345ff" />

> Refactored _get_wss_url method:
Now retrieves the base URL using the latest version of SyncClientWrapper. 
> Introduced New Test Case:
Added tests to validate the correct construction of WSS URLs under different base URL scenarios (both HTTPS and HTTP). 

Related issues: 
https://github.com/elevenlabs/elevenlabs-python/issues/519
