### PR TITLE
[SDK v2] Deprecate generate and clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,23 @@ pip install elevenlabs
 
 1. **Eleven Multilingual v2** (`eleven_multilingual_v2`)
 
-   - Excels in stability, language diversity, and accent accuracy
-   - Supports 29 languages
-   - Recommended for most use cases
+    - Excels in stability, language diversity, and accent accuracy
+    - Supports 29 languages
+    - Recommended for most use cases
+
+2. **Eleven Flash v2.5** (`eleven_flash_v2_5`)
+
+    - Ultra-low latency
+    - Supports 32 languages
+    - Faster model, 50% lower price per character
 
 2. **Eleven Turbo v2.5** (`eleven_turbo_v2_5`)
-   - High quality, lowest latency
-   - Ideal for developer use cases where speed is crucial
-   - Supports 32 languages
 
-For more detailed information about these models and others, visit the [ElevenLabs Models documentation](https://elevenlabs.io/docs/speech-synthesis/models).
+    - Good balance of quality and latency
+    - Ideal for developer use cases where speed is crucial
+    - Supports 32 languages
+
+For more detailed information about these models and others, visit the [ElevenLabs Models documentation](https://elevenlabs.io/docs/models).
 
 ```py
 from dotenv import load_dotenv
@@ -96,10 +103,10 @@ from elevenlabs.client import ElevenLabs
 from elevenlabs import play
 
 client = ElevenLabs(
-  api_key="YOUR_API_KEY", # Defaults ELEVENLABS_API_KEY
+  api_key="YOUR_API_KEY",
 )
 
-voice = client.clone(
+voice = client.voices.add(
     name="Alex",
     description="An old American male voice with a slight hoarseness in his throat. Perfect for news", # Optional
     files=["./sample_0.mp3", "./sample_1.mp3", "./sample_2.mp3"],
@@ -132,32 +139,6 @@ for chunk in audio_stream:
 
 ```
 
-### Input streaming
-
-Stream text chunks into audio as it's being generated, with <1s latency. Note: if chunks don't end with space or punctuation (" ", ".", "?", "!"), the stream will wait for more text.
-
-```py
-from elevenlabs.client import ElevenLabs
-from elevenlabs import stream
-
-client = ElevenLabs(
-  api_key="YOUR_API_KEY", # Defaults to ELEVENLABS_API_KEY
-)
-
-def text_stream():
-    yield "Hi there, I'm Eleven "
-    yield "I'm a text to speech API "
-
-audio_stream = client.generate(
-    text=text_stream(),
-    voice="Brian",
-    model="eleven_multilingual_v2",
-    stream=True
-)
-
-stream(audio_stream)
-```
-
 ## Async Client
 
 Use `AsyncElevenLabs` if you want to make API calls asynchronously.
@@ -168,7 +149,7 @@ import asyncio
 from elevenlabs.client import AsyncElevenLabs
 
 eleven = AsyncElevenLabs(
-  api_key="MY_API_KEY" # Defaults to ELEVENLABS_API_KEY
+  api_key="MY_API_KEY"
 )
 
 async def print_models() -> None:

--- a/src/elevenlabs/client.py
+++ b/src/elevenlabs/client.py
@@ -3,6 +3,8 @@ import json
 import re
 import os
 import httpx
+import warnings
+from functools import wraps
 
 from typing import Iterator, Optional, Union, \
   Optional, AsyncIterator
@@ -42,6 +44,38 @@ def get_base_url_host(base_url: str) -> str:
 
 # this is used as the default value for optional parameters
 OMIT = typing.cast(typing.Any, ...)
+
+
+def deprecated(func):
+    """
+    This is a decorator which can be used to mark functions as deprecated.
+    It will result in a warning being emitted when the function is used.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        warnings.warn(
+            f"The method {func.__name__} is deprecated and will be removed in a future version.",
+            category=DeprecationWarning,
+            stacklevel=2
+        )
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def deprecated_async(func):
+    """
+    This is a decorator which can be used to mark async functions as deprecated.
+    It will result in a warning being emitted when the function is used.
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        warnings.warn(
+            f"The method {func.__name__} is deprecated and will be removed in a future version.",
+            category=DeprecationWarning,
+            stacklevel=2
+        )
+        return await func(*args, **kwargs)
+    return wrapper
 
 
 class ElevenLabs(BaseElevenLabs):
@@ -89,6 +123,7 @@ class ElevenLabs(BaseElevenLabs):
         )
         self.text_to_speech = RealtimeTextToSpeechClient(client_wrapper=self._client_wrapper)
 
+    @deprecated
     def clone(
       self,
       name: str,
@@ -124,6 +159,8 @@ class ElevenLabs(BaseElevenLabs):
           request_options=request_options
         )
 
+
+    @deprecated
     def generate(
       self,
       *,
@@ -266,6 +303,7 @@ class AsyncElevenLabs(AsyncBaseElevenLabs):
     )
     """
 
+    @deprecated_async
     async def clone(
       self,
       name: str,
@@ -304,6 +342,7 @@ class AsyncElevenLabs(AsyncBaseElevenLabs):
           request_options=request_options
         )
 
+    @deprecated_async
     async def generate(
       self,
       *,


### PR DESCRIPTION
Deprecate `generate` and `clone` methods and update the readme to not use them.