### PR TITLE
Fixing circular imports (option 2)

### DIFF
--- a/src/elevenlabs/types/object_json_schema_property_input.py
+++ b/src/elevenlabs/types/object_json_schema_property_input.py
@@ -24,7 +24,7 @@ class ObjectJsonSchemaPropertyInput(UncheckedBaseModel):
             smart_union = True
             extra = pydantic.Extra.allow
 
-
+from .array_json_schema_property_input import ArrayJsonSchemaPropertyInput  # noqa: E402, I001
 from .object_json_schema_property_input_properties_value import ObjectJsonSchemaPropertyInputPropertiesValue  # noqa: E402, I001
 
-update_forward_refs(ObjectJsonSchemaPropertyInput)
+update_forward_refs(ObjectJsonSchemaPropertyInput, ArrayJsonSchemaPropertyInput=ArrayJsonSchemaPropertyInput)

--- a/src/elevenlabs/types/object_json_schema_property_output.py
+++ b/src/elevenlabs/types/object_json_schema_property_output.py
@@ -25,6 +25,8 @@ class ObjectJsonSchemaPropertyOutput(UncheckedBaseModel):
             extra = pydantic.Extra.allow
 
 
+
+from .array_json_schema_property_output import ArrayJsonSchemaPropertyOutput  # noqa: E402, I001
 from .object_json_schema_property_output_properties_value import ObjectJsonSchemaPropertyOutputPropertiesValue  # noqa: E402, I001
 
-update_forward_refs(ObjectJsonSchemaPropertyOutput)
+update_forward_refs(ObjectJsonSchemaPropertyOutput, ArrayJsonSchemaPropertyOutput=ArrayJsonSchemaPropertyOutput)

--- a/tests/test_convai_imports.py
+++ b/tests/test_convai_imports.py
@@ -1,0 +1,6 @@
+from elevenlabs import ElevenLabs
+
+
+def test_convai_imports():
+    client = ElevenLabs(api_key="")
+    client.conversational_ai.agents

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -1,0 +1,11 @@
+from elevenlabs import AgentWorkflowRequestModel, ObjectJsonSchemaPropertyInput, ObjectJsonSchemaPropertyOutput
+
+
+def test_recursive_models():
+    # Should be able to import and use the recursive types without PydanticUserError
+    # ObjectJsonSchemaPropertyInput has no required fields, so it can be instantiated
+    ObjectJsonSchemaPropertyInput()
+    
+    ObjectJsonSchemaPropertyOutput()
+
+    AgentWorkflowRequestModel()


### PR DESCRIPTION
This brings back the targeted import changes from https://github.com/elevenlabs/elevenlabs-python/pull/622 (from https://github.com/fern-api/fern/pull/9251) and appears to fix the models users reported issues with.

It's worth trying even more models, but tricky because we are trying to replicate just importing a single model.