### PR TITLE
Fix: Correct is_base64_encoded alias in AdditionalFormatResponseModel (#694)

### DIFF
--- a/src/elevenlabs/types/additional_format_response_model.py
+++ b/src/elevenlabs/types/additional_format_response_model.py
@@ -25,7 +25,7 @@ class AdditionalFormatResponseModel(UncheckedBaseModel):
     The content type of the additional format.
     """
 
-    is_base_64_encoded: typing_extensions.Annotated[bool, FieldMetadata(alias="is_base64_encoded")] = pydantic.Field()
+    is_base_64_encoded: bool = pydantic.Field(alias="is_base64_encoded")
     """
     Whether the content is base64 encoded.
     """

--- a/tests/test_additional_format_response.py
+++ b/tests/test_additional_format_response.py
@@ -1,0 +1,14 @@
+from elevenlabs.types import AdditionalFormatResponseModel
+
+def test_alias_parsing():
+    data = {
+        "requested_format": "wav",
+        "file_extension": "wav",
+        "content_type": "audio/wav",
+        "is_base64_encoded": True,
+        "content": "abcd1234"
+    }
+
+    model = AdditionalFormatResponseModel(**data)
+
+    assert model.is_base_64_encoded is True


### PR DESCRIPTION
This PR fixes Issue #694, where the is_base_64_encoded field in AdditionalFormatResponseModel was not correctly decoded under Pydantic v2.

The underlying problem was that the model used:

Annotated[..., FieldMetadata(alias="is_base64_encoded")]

but did not pass the alias to pydantic.Field(), causing Pydantic v2 to ignore the alias. As a result, incoming JSON fields named is_base64_encoded were not mapped correctly.

What Was Changed

Before:

is_base_64_encoded: typing_extensions.Annotated[
    bool, FieldMetadata(alias="is_base64_encoded")
] = pydantic.Field()

After (fixed):

is_base_64_encoded: bool = pydantic.Field(alias="is_base64_encoded")

This ensures proper alias resolution across both Pydantic v1 and v2.

Why This Fix Is Needed

Pydantic v2 requires explicit alias definition in Field(...).

Without this, the field is_base64_encoded sent by the API was not recognized.

This caused failures when decoding additional format responses, particularly when using segmented JSON.

This fix aligns behavior with expectations and resolves user-reported decoding issues.

Test Coverage

A new test was added to validate the alias mapping:

def test_alias_parsing():
    data = {
        "requested_format": "wav",
        "file_extension": "wav",
        "content_type": "audio/wav",
        "is_base64_encoded": True,
        "content": "abcd1234"
    }

    model = AdditionalFormatResponseModel(**data)

    assert model.is_base_64_encoded is True

Test Results

All tests passed successfully.

📸 Test Screenshot:

<img width="1372" height="317" alt="image" src="https://github.com/user-attachments/assets/62622911-680c-4ec2-b1ad-3b83a9817c99" />


Related Issue

Fixes #694

Notes

The change is backward-compatible.

Verified using pip install -e . inside a GitHub Codespace.

No API behavior changes; only model parsing improvements.
