### PR TITLE
[Agents] Fixed bug with init and user_id

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -403,7 +403,7 @@ class BaseConversation:
                     "source": "python_sdk",
                     "version": __version__,
                 },
-                **({"user_id": self.config.user_id} if self.config.user_id else {}),
+                **({"user_id": self.user_id} if self.user_id else {}),
             }
         )
 

--- a/tests/test_async_convai.py
+++ b/tests/test_async_convai.py
@@ -71,12 +71,11 @@ async def test_async_conversation_basic_flow():
     agent_response_callback = AsyncMock()
     test_user_id = "test_user_123"
 
-    # Setup the conversation
-    config = ConversationInitiationData(user_id=test_user_id)
+    # Setup the conversation with user_id passed directly to the constructor
     conversation = AsyncConversation(
         client=mock_client,
         agent_id=TEST_AGENT_ID,
-        config=config,
+        user_id=test_user_id,
         requires_auth=False,
         audio_interface=MockAsyncAudioInterface(),
         callback_agent_response=agent_response_callback,
@@ -109,7 +108,7 @@ async def test_async_conversation_basic_flow():
     assert init_message["user_id"] == test_user_id
     agent_response_callback.assert_called_once_with("Hello there!")
     assert conversation._conversation_id == TEST_CONVERSATION_ID
-    assert conversation.config.user_id == test_user_id
+    assert conversation.user_id == test_user_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -59,12 +59,11 @@ def test_conversation_basic_flow():
     agent_response_callback = MagicMock()
     test_user_id = "test_user_123"
 
-    # Setup the conversation
-    config = ConversationInitiationData(user_id=test_user_id)
+    # Setup the conversation with user_id passed directly to the constructor
     conversation = Conversation(
         client=mock_client,
         agent_id=TEST_AGENT_ID,
-        config=config,
+        user_id=test_user_id,
         requires_auth=False,
         audio_interface=MockAudioInterface(),
         callback_agent_response=agent_response_callback,
@@ -99,7 +98,7 @@ def test_conversation_basic_flow():
     assert init_message["user_id"] == test_user_id
     agent_response_callback.assert_called_once_with("Hello there!")
     assert conversation._conversation_id == TEST_CONVERSATION_ID
-    assert conversation.config.user_id == test_user_id
+    assert conversation.user_id == test_user_id
 
 
 def test_conversation_with_auth():


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/elevenlabs-python/issues/679

Fixes an issue where `user_id` was incorrectly being grabbed from `self.config` instead of just `self`, meaning it was always set to `None`.