### PR TITLE
Fix SSE Accept header to include application/json

### DIFF
--- a/src/elevenlabs/core/http_sse/_api.py
+++ b/src/elevenlabs/core/http_sse/_api.py
@@ -90,7 +90,7 @@ class EventSource:
 @contextmanager
 def connect_sse(client: httpx.Client, method: str, url: str, **kwargs: Any) -> Iterator[EventSource]:
     headers = kwargs.pop("headers", {})
-    headers["Accept"] = "text/event-stream"
+    headers["Accept"] = "application/json, text/event-stream"
     headers["Cache-Control"] = "no-store"
 
     with client.stream(method, url, headers=headers, **kwargs) as response:
@@ -105,7 +105,7 @@ async def aconnect_sse(
     **kwargs: Any,
 ) -> AsyncIterator[EventSource]:
     headers = kwargs.pop("headers", {})
-    headers["Accept"] = "text/event-stream"
+    headers["Accept"] = "application/json, text/event-stream"
     headers["Cache-Control"] = "no-store"
 
     async with client.stream(method, url, headers=headers, **kwargs) as response:


### PR DESCRIPTION
## Description

Fixes #671 - Updates SSE Accept header to include `application/json` for MCP server compatibility. Some servers like Composio require both content types, causing 406 errors without this change.




## Changes Made


- Modified `connect_sse` and `aconnect_sse` to send `Accept: application/json, text/event-stream` instead of `Accept: text/event-stream`
- Maintains backward compatibility by still including `text/event-stream` in the Accept header