### PR TITLE
Fix: update imports for local only tests

### DIFF
--- a/tests/test_audio_isolation.py
+++ b/tests/test_audio_isolation.py
@@ -1,4 +1,4 @@
-from elevenlabs import play
+from elevenlabs.play import play
 from elevenlabs.client import ElevenLabs
 
 from .utils import IN_GITHUB, DEFAULT_VOICE_FILE

--- a/tests/test_sts.py
+++ b/tests/test_sts.py
@@ -1,4 +1,4 @@
-from elevenlabs import play
+from elevenlabs.play import play
 from elevenlabs.client import ElevenLabs
 
 from .utils import IN_GITHUB, DEFAULT_VOICE, DEFAULT_VOICE_FILE

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,6 +1,7 @@
 import asyncio
 
-from elevenlabs import VoiceSettings, play, Voice
+from elevenlabs import VoiceSettings, Voice
+from elevenlabs.play import play
 from elevenlabs.client import AsyncElevenLabs, ElevenLabs
 
 from .utils import IN_GITHUB, DEFAULT_TEXT, DEFAULT_VOICE, DEFAULT_MODEL

--- a/tests/test_ttsfx.py
+++ b/tests/test_ttsfx.py
@@ -1,4 +1,4 @@
-from elevenlabs import play
+from elevenlabs.play import play
 from elevenlabs.client import ElevenLabs
 
 from .utils import IN_GITHUB


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-only import paths and do not affect runtime logic or API behavior.
> 
> **Overview**
> Updates local-only audio-related tests to import `play` from `elevenlabs.play` instead of `elevenlabs`, aligning with the package’s new module structure and keeping `Voice`/`VoiceSettings` imports unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1dacb375545d8544e94c39db07a5ef9b11f5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->