### PR TITLE
fix: correct notebook install hint

### DIFF
--- a/src/elevenlabs/play.py
+++ b/src/elevenlabs/play.py
@@ -22,7 +22,7 @@ def play(
             from IPython.display import Audio, display  # type: ignore
         except ModuleNotFoundError:
             message = (
-                "`pip install ipython` required when `notebook=False` "
+                "`pip install ipython` required when `notebook=True` "
             )
             raise ValueError(message)
 


### PR DESCRIPTION
## Summary
- Correct the `play(..., notebook=True)` missing dependency message so it references `notebook=True` instead of `notebook=False`.

## Verification
- `python -m py_compile src/elevenlabs/play.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a user-facing error string and does not affect audio playback logic or dependencies.
> 
> **Overview**
> Fixes a misleading error message in `play()` so the `IPython` install hint correctly says it’s required when `notebook=True` (instead of `notebook=False`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceeb52ee5706d02f0f4a7e66866e83727fb4c948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->