### PR TITLE
Add keyterms and no_verbatim to Scribe realtime API

### DIFF
--- a/src/elevenlabs/realtime/scribe.py
+++ b/src/elevenlabs/realtime/scribe.py
@@ -67,6 +67,8 @@ class RealtimeAudioOptions(typing.TypedDict, total=False):
     min_silence_duration_ms: int
     language_code: str
     include_timestamps: bool
+    keyterms: typing.List[str]
+    no_verbatim: bool
 
 
 class RealtimeUrlOptions(typing.TypedDict, total=False):
@@ -93,6 +95,8 @@ class RealtimeUrlOptions(typing.TypedDict, total=False):
     min_silence_duration_ms: int
     language_code: str
     include_timestamps: bool
+    keyterms: typing.List[str]
+    no_verbatim: bool
 
 
 class ScribeRealtime:
@@ -197,6 +201,8 @@ class ScribeRealtime:
         min_silence_duration_ms = options.get("min_silence_duration_ms")
         language_code = options.get("language_code")
         include_timestamps = options.get("include_timestamps", False)
+        keyterms = options.get("keyterms")
+        no_verbatim = options.get("no_verbatim")
 
         if not audio_format or not sample_rate:
             raise ValueError("audio_format and sample_rate are required for manual audio mode")
@@ -212,6 +218,8 @@ class ScribeRealtime:
             min_silence_duration_ms=min_silence_duration_ms,
             language_code=language_code,
             include_timestamps=include_timestamps,
+            keyterms=keyterms,
+            no_verbatim=no_verbatim,
         )
 
         # Connect to WebSocket
@@ -244,6 +252,8 @@ class ScribeRealtime:
         min_silence_duration_ms = options.get("min_silence_duration_ms")
         language_code = options.get("language_code")
         include_timestamps = options.get("include_timestamps", False)
+        keyterms = options.get("keyterms")
+        no_verbatim = options.get("no_verbatim")
 
         if not url:
             raise ValueError("url is required for URL mode")
@@ -263,6 +273,8 @@ class ScribeRealtime:
             min_silence_duration_ms=min_silence_duration_ms,
             language_code=language_code,
             include_timestamps=include_timestamps,
+            keyterms=keyterms,
+            no_verbatim=no_verbatim,
         )
 
         # Connect to WebSocket
@@ -365,7 +377,9 @@ class ScribeRealtime:
         min_speech_duration_ms: typing.Optional[int] = None,
         min_silence_duration_ms: typing.Optional[int] = None,
         language_code: typing.Optional[str] = None,
-        include_timestamps: typing.Optional[bool] = None
+        include_timestamps: typing.Optional[bool] = None,
+        keyterms: typing.Optional[typing.List[str]] = None,
+        no_verbatim: typing.Optional[bool] = None,
     ) -> str:
         """Build the WebSocket URL with query parameters"""
         params = [
@@ -384,6 +398,11 @@ class ScribeRealtime:
                 params.append((key, str(value)))
         if include_timestamps is not None:
             params.append(("include_timestamps", str(include_timestamps).lower()))
+        if keyterms is not None:
+            for term in keyterms:
+                params.append(("keyterms", term))
+        if no_verbatim is not None:
+            params.append(("no_verbatim", str(no_verbatim).lower()))
 
         return build_ws_url(self.base_url, ["v1", "speech-to-text", "realtime"], params)
 

--- a/tests/test_stt_realtime.py
+++ b/tests/test_stt_realtime.py
@@ -95,6 +95,51 @@ class TestBuildWebsocketUrl:
 
         assert url.startswith("ws://localhost:8080")
 
+    def test_includes_keyterms_as_repeated_query_params(self):
+        """Test that keyterms are included as repeated query params"""
+        url = self.scribe._build_websocket_url(
+            model_id="scribe_v2_realtime",
+            audio_format="pcm_16000",
+            commit_strategy="manual",
+            keyterms=["ElevenLabs", "Scribe"],
+        )
+
+        assert "keyterms=ElevenLabs" in url
+        assert "keyterms=Scribe" in url
+
+    def test_includes_no_verbatim_true(self):
+        """Test that no_verbatim=true is included when set to True"""
+        url = self.scribe._build_websocket_url(
+            model_id="scribe_v2_realtime",
+            audio_format="pcm_16000",
+            commit_strategy="manual",
+            no_verbatim=True,
+        )
+
+        assert "no_verbatim=true" in url
+
+    def test_includes_no_verbatim_false(self):
+        """Test that no_verbatim=false is included when set to False"""
+        url = self.scribe._build_websocket_url(
+            model_id="scribe_v2_realtime",
+            audio_format="pcm_16000",
+            commit_strategy="manual",
+            no_verbatim=False,
+        )
+
+        assert "no_verbatim=false" in url
+
+    def test_omits_keyterms_and_no_verbatim_when_not_specified(self):
+        """Test that keyterms and no_verbatim are omitted when not specified"""
+        url = self.scribe._build_websocket_url(
+            model_id="scribe_v2_realtime",
+            audio_format="pcm_16000",
+            commit_strategy="manual",
+        )
+
+        assert "keyterms" not in url
+        assert "no_verbatim" not in url
+
 
 class TestConnectValidation:
     """Tests for connect method validation"""


### PR DESCRIPTION
## Summary
- Add `keyterms` option (`list[str]`) to bias the Scribe model towards specific terms. Passed as repeated query params on the WebSocket URL.
- Add `no_verbatim` option (`bool`) to remove filler words, false starts, and disfluencies from transcripts.
- Both options added to `RealtimeAudioOptions` and `RealtimeUrlOptions` TypedDicts and threaded through to `_build_websocket_url`.

Python equivalent of elevenlabs/elevenlabs-js#376.

## Test plan
- [x] Unit tests for `keyterms` repeated query params
- [x] Unit tests for `no_verbatim` true/false query param
- [x] Unit test confirming params omitted when not specified
- [x] All files edited are in `.fernignore` (hand-maintained)
- [x] All 17 tests pass
- [ ] Manual verification with a real Scribe realtime session using `keyterms`
- [ ] Manual verification with `no_verbatim=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds optional query parameters and tests, with minimal impact on existing behavior unless callers start supplying the new options.
> 
> **Overview**
> Extends Scribe realtime connection options with **`keyterms`** (list of bias terms) and **`no_verbatim`** (boolean transcript cleanup) for both manual-audio and URL-streaming modes.
> 
> Threads these values through `connect()` into `_build_websocket_url`, encoding `keyterms` as repeated `keyterms=<term>` query params and `no_verbatim` as a lowercased boolean when provided, and adds unit tests verifying correct inclusion and omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14583cd6d71b58e3f7991fa8602cbf9efd10d61b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->