### PR TITLE
fix: add url_utils.py to .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -9,6 +9,7 @@ src/elevenlabs/play.py
 src/elevenlabs/webhooks_custom.py
 src/elevenlabs/music_custom.py
 src/elevenlabs/speech_to_text_custom.py
+src/elevenlabs/url_utils.py
 src/elevenlabs/realtime/
 
 # Ignore CI files


### PR DESCRIPTION
## Summary
- Adds `src/elevenlabs/url_utils.py` to `.fernignore` so Fern regeneration stops deleting this custom utility module
- Fixes mypy compile failures in Fern regeneration PRs (4 files import from `url_utils`)

## Test plan
- [x] Verified `url_utils.py` exists on main and is imported by `scribe.py`, `realtime_tts.py`, `conversation.py`, and `test_url_utils.py`
- [ ] After merging, re-dispatch Python SDK regeneration and confirm compile passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to Fern ignore configuration; it only affects codegen/regeneration behavior and not runtime logic.
> 
> **Overview**
> Adds `src/elevenlabs/url_utils.py` to `.fernignore` so Fern regeneration stops overwriting/removing this custom module (which is imported by several SDK files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23ca1d82fd5039eb9f6b2392121cdd0d0408c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->