### PR TITLE
Fix test in CI

### DIFF
--- a/tests/test_speech_engine_auth.py
+++ b/tests/test_speech_engine_auth.py
@@ -188,7 +188,8 @@ class TestVerifyRequest:
 
 class TestServerApiKeyRequirement:
     @pytest.mark.asyncio
-    async def test_raises_without_api_key(self) -> None:
+    async def test_raises_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
         from elevenlabs.speech_engine import SpeechEngineServer
 
         server = SpeechEngineServer(port=0)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a unit test by explicitly clearing an env var to avoid CI/environment leakage; no production code changes.
> 
> **Overview**
> Makes the `SpeechEngineServer` “missing API key” test deterministic by injecting `monkeypatch` and explicitly unsetting `ELEVENLABS_API_KEY` before asserting `serve()` raises a `RuntimeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3976d23a7aaa7c729b087eeea8e8be5ce70ba27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->