### PR TITLE
fix: add speech_engine_custom.py to .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -12,6 +12,7 @@ src/elevenlabs/speech_to_text_custom.py
 src/elevenlabs/url_utils.py
 src/elevenlabs/realtime/
 src/elevenlabs/speech_engine/
+src/elevenlabs/speech_engine_custom.py
 
 # Ignore CI files
 .github/


### PR DESCRIPTION
## Summary
- Adds `src/elevenlabs/speech_engine_custom.py` to `.fernignore` so Fern regeneration stops deleting this custom module
- Fixes `ModuleNotFoundError: No module named 'elevenlabs.speech_engine_custom'` in Fern regeneration PRs (imported by `client.py`)
- Same pattern as #782 (`url_utils.py`)

## Test plan
- [x] Verified `speech_engine_custom.py` exists on main and is imported by `client.py`
- [ ] After merging, re-dispatch Python SDK regeneration and confirm compile passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only `.fernignore`, affecting code generation behavior but not runtime logic; main risk is accidentally excluding a file that should be generated.
> 
> **Overview**
> Prevents Fern regeneration from deleting/overwriting the custom `src/elevenlabs/speech_engine_custom.py` module by adding it to `.fernignore`.
> 
> This keeps `client.py` imports of `SpeechEngineClient`/`AsyncSpeechEngineClient` stable across regen PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46da3dce093a15a2420c8befdce34eb22ed6b92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->