### PR TITLE
Allow passing `headers, follow_redirects` from `ElevenLabs`, `AsyncElevenLabs` to parent/base class

### DIFF
--- a/src/elevenlabs/client.py
+++ b/src/elevenlabs/client.py
@@ -33,7 +33,11 @@ class ElevenLabs(BaseElevenLabs):
 
         - api_key: typing.Optional[str].
 
+        - headers: typing.Optional[typing.Dict[str, str]]. Additional headers to send with every request.
+
         - timeout: typing.Optional[float]. The timeout to be used, in seconds, for requests by default the timeout is 240 seconds.
+
+        - follow_redirects: typing.Optional[bool]. Whether the default httpx client should follow redirects. Defaults to True. Ignored when a custom `httpx_client` is supplied.
 
         - httpx_client: typing.Optional[httpx.Client]. The httpx client to use for making requests, a preconfigured client is used by default, however this is useful should you want to pass in any custom httpx configuration.
     ---
@@ -49,14 +53,18 @@ class ElevenLabs(BaseElevenLabs):
         base_url: typing.Optional[str] = None,
         environment: ElevenLabsEnvironment = ElevenLabsEnvironment.PRODUCTION,
         api_key: typing.Optional[str] = os.getenv("ELEVENLABS_API_KEY"),
+        headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = 240,
+        follow_redirects: typing.Optional[bool] = True,
         httpx_client: typing.Optional[httpx.Client] = None
     ):
         super().__init__(
             base_url=base_url,
             environment=environment,
             api_key=api_key,
+            headers=headers,
             timeout=timeout,
+            follow_redirects=follow_redirects,
             httpx_client=httpx_client
         )
         self._text_to_speech = RealtimeTextToSpeechClient(client_wrapper=self._client_wrapper)
@@ -83,7 +91,11 @@ class AsyncElevenLabs(AsyncBaseElevenLabs):
 
         - api_key: typing.Optional[str].
 
+        - headers: typing.Optional[typing.Dict[str, str]]. Additional headers to send with every request.
+
         - timeout: typing.Optional[float]. The timeout to be used, in seconds, for requests by default the timeout is 240 seconds.
+
+        - follow_redirects: typing.Optional[bool]. Whether the default httpx client should follow redirects. Defaults to True. Ignored when a custom `httpx_client` is supplied.
 
         - httpx_client: typing.Optional[httpx.AsyncClient]. The httpx client to use for making requests, a preconfigured client is used by default, however this is useful should you want to pass in any custom httpx configuration.
     ---
@@ -100,14 +112,18 @@ class AsyncElevenLabs(AsyncBaseElevenLabs):
         base_url: typing.Optional[str] = None,
         environment: ElevenLabsEnvironment = ElevenLabsEnvironment.PRODUCTION,
         api_key: typing.Optional[str] = os.getenv("ELEVENLABS_API_KEY"),
+        headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = 240,
+        follow_redirects: typing.Optional[bool] = True,
         httpx_client: typing.Optional[httpx.AsyncClient] = None
     ):
         super().__init__(
             base_url=base_url,
             environment=environment,
             api_key=api_key,
+            headers=headers,
             timeout=timeout,
+            follow_redirects=follow_redirects,
             httpx_client=httpx_client
         )
         self._webhooks = AsyncWebhooksClient(client_wrapper=self._client_wrapper)

--- a/tests/test_client_headers.py
+++ b/tests/test_client_headers.py
@@ -1,0 +1,106 @@
+"""Tests that the user-facing ElevenLabs / AsyncElevenLabs classes forward
+the ``headers`` and ``follow_redirects`` kwargs through to the underlying
+client wrapper / httpx client.
+
+Regression coverage for the case where ``ElevenLabs(headers={...})`` and
+``ElevenLabs(follow_redirects=False)`` raised TypeError because the
+subclass's hand-rolled ``__init__`` did not accept or forward kwargs that
+``BaseElevenLabs`` supports.
+"""
+
+import pytest
+
+from elevenlabs.client import AsyncElevenLabs, ElevenLabs
+
+
+def test_sync_client_accepts_headers_kwarg():
+    """ElevenLabs(headers=...) does not raise and stores the headers."""
+    custom = {"x-trace-id": "abc-123", "x-tenant": "acme"}
+    client = ElevenLabs(api_key="sk-test", headers=custom)
+    assert client._client_wrapper.get_custom_headers() == custom
+
+
+def test_sync_client_headers_default_is_none():
+    """Omitting headers leaves the wrapper's custom headers unset (backward-compatible)."""
+    client = ElevenLabs(api_key="sk-test")
+    assert client._client_wrapper.get_custom_headers() is None
+
+
+def test_sync_client_custom_headers_appear_in_merged_headers():
+    """Headers from the constructor are merged into get_headers() output."""
+    client = ElevenLabs(api_key="sk-test", headers={"x-trace-id": "abc-123"})
+    merged = client._client_wrapper.get_headers()
+    assert merged.get("x-trace-id") == "abc-123"
+
+
+async def test_async_client_accepts_headers_kwarg():
+    """AsyncElevenLabs(headers=...) does not raise and stores the headers."""
+    custom = {"x-trace-id": "abc-123"}
+    client = AsyncElevenLabs(api_key="sk-test", headers=custom)
+    assert client._client_wrapper.get_custom_headers() == custom
+
+
+async def test_async_client_headers_default_is_none():
+    """Omitting headers on AsyncElevenLabs leaves custom headers unset."""
+    client = AsyncElevenLabs(api_key="sk-test")
+    assert client._client_wrapper.get_custom_headers() is None
+
+
+def test_sync_constructor_signature_advertises_headers():
+    """`headers` is a documented keyword-only parameter on ElevenLabs.__init__."""
+    import inspect
+
+    sig = inspect.signature(ElevenLabs.__init__)
+    assert "headers" in sig.parameters
+    assert sig.parameters["headers"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_async_constructor_signature_advertises_headers():
+    """`headers` is a documented keyword-only parameter on AsyncElevenLabs.__init__."""
+    import inspect
+
+    sig = inspect.signature(AsyncElevenLabs.__init__)
+    assert "headers" in sig.parameters
+    assert sig.parameters["headers"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_sync_client_accepts_follow_redirects_false():
+    """ElevenLabs(follow_redirects=False) propagates to the default httpx client."""
+    client = ElevenLabs(api_key="sk-test", follow_redirects=False)
+    assert client._client_wrapper.httpx_client.httpx_client.follow_redirects is False
+
+
+def test_sync_client_follow_redirects_default_is_true():
+    """Omitting follow_redirects keeps the parent's default of True."""
+    client = ElevenLabs(api_key="sk-test")
+    assert client._client_wrapper.httpx_client.httpx_client.follow_redirects is True
+
+
+def test_async_client_accepts_follow_redirects_false():
+    """AsyncElevenLabs(follow_redirects=False) propagates to the default httpx client."""
+    client = AsyncElevenLabs(api_key="sk-test", follow_redirects=False)
+    assert client._client_wrapper.httpx_client.httpx_client.follow_redirects is False
+
+
+def test_async_client_follow_redirects_default_is_true():
+    """Omitting follow_redirects on AsyncElevenLabs keeps the parent's default of True."""
+    client = AsyncElevenLabs(api_key="sk-test")
+    assert client._client_wrapper.httpx_client.httpx_client.follow_redirects is True
+
+
+def test_sync_constructor_signature_advertises_follow_redirects():
+    """`follow_redirects` is a documented keyword-only parameter on ElevenLabs.__init__."""
+    import inspect
+
+    sig = inspect.signature(ElevenLabs.__init__)
+    assert "follow_redirects" in sig.parameters
+    assert sig.parameters["follow_redirects"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_async_constructor_signature_advertises_follow_redirects():
+    """`follow_redirects` is a documented keyword-only parameter on AsyncElevenLabs.__init__."""
+    import inspect
+
+    sig = inspect.signature(AsyncElevenLabs.__init__)
+    assert "follow_redirects" in sig.parameters
+    assert sig.parameters["follow_redirects"].kind == inspect.Parameter.KEYWORD_ONLY


### PR DESCRIPTION
# Summary
- The classes `ElevenLabs` and `AsyncElevenLabs` extend base classes that support the `headers` and `follow_redirects` as constructor parameters, but don't expose these on their own constructors, making it impossible to actually use these.
- Expose these in the child classes and pass onto parent constructors.
- Change should be backwards compatible because parameters are added as optional with default values identical to their parent classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional constructor kwargs with parent-aligned defaults; behavior change only for callers who previously could not pass these options.
> 
> **Overview**
> **`ElevenLabs` and `AsyncElevenLabs` now accept optional `headers` and `follow_redirects` and pass them to their base classes**, fixing `TypeError` when callers used kwargs the base already supported but the public subclasses did not forward.
> 
> Constructor docs are updated for both sync and async clients. Defaults match the parent (`headers=None`, `follow_redirects=True`), so existing call sites stay unchanged.
> 
> New tests in `test_client_headers.py` cover forwarding to the client wrapper, merged request headers, httpx redirect behavior, and keyword-only signatures for both client types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d34f2cb3e359aadd611374507426a642f17294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->