### PR TITLE
Add HMAC-signed post-call webhook config for on-prem conversations

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -386,7 +386,8 @@ class OnPremInitiationData:
         # The orchestrator rejects the connection when both the legacy URL field
         # and its typed counterpart are set; fail here with a clearer error. The
         # checks mirror the orchestrator's: typed field compared against None,
-        # legacy URL by truthiness.
+        # legacy URL by truthiness. An empty legacy URL counts as absent on both
+        # sides (the typed config wins), so it must not raise here.
         if post_call_transcription_webhook is not None and post_call_transcription_webhook_url:
             raise ValueError(
                 "Set either post_call_transcription_webhook or post_call_transcription_webhook_url, not both."

--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -348,6 +348,24 @@ class ConversationInitiationData:
         self.user_id = user_id
 
 
+@dataclass
+class PostCallWebhookConfig:
+    """Post-call webhook destination for on-prem deployments.
+
+    When ``hmac_secret`` is set (16 characters minimum), each delivery carries an
+    ``ElevenLabs-Signature`` header: ``t=<unix_ts>,v0=<hex hmac_sha256(secret, "{ts}.{body}")>``.
+    """
+
+    url: str
+    hmac_secret: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        message: dict = {"url": self.url}
+        if self.hmac_secret is not None:
+            message["hmac_secret"] = self.hmac_secret
+        return message
+
+
 class OnPremInitiationData:
     """Configuration options for the Conversation in on-prem mode."""
 
@@ -360,7 +378,19 @@ class OnPremInitiationData:
         override_agent_config_list: Optional[List[dict]] = None,
         tools_config_list: Optional[List[dict]] = None,
         prompt_knowledge_base: Optional[List[str]] = None,
+        post_call_transcription_webhook: Optional[PostCallWebhookConfig] = None,
+        post_call_audio_webhook: Optional[PostCallWebhookConfig] = None,
     ):
+        # The orchestrator rejects the connection when both the legacy URL field
+        # and its typed counterpart are set; fail here with a clearer error.
+        if post_call_transcription_webhook and post_call_transcription_webhook_url:
+            raise ValueError(
+                "Set either post_call_transcription_webhook or post_call_transcription_webhook_url, not both."
+            )
+        if post_call_audio_webhook and post_call_audio_webhook_url:
+            raise ValueError(
+                "Set either post_call_audio_webhook or post_call_audio_webhook_url, not both."
+            )
         self.on_prem_conversation_url = on_prem_conversation_url
         self.post_call_transcription_webhook_url = post_call_transcription_webhook_url
         self.post_call_audio_webhook_url = post_call_audio_webhook_url
@@ -368,6 +398,8 @@ class OnPremInitiationData:
         self.override_agent_config_list = override_agent_config_list
         self.tools_config_list = tools_config_list
         self.prompt_knowledge_base = prompt_knowledge_base
+        self.post_call_transcription_webhook = post_call_transcription_webhook
+        self.post_call_audio_webhook = post_call_audio_webhook
 
 
 @dataclass
@@ -445,17 +477,24 @@ class BaseConversation:
         return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(existing_params, quote_via=urllib.parse.quote)))
 
     def _create_on_prem_initiation_message(self):
-        return json.dumps(
-            {
-                "type": "enclave_setup_config",
-                "agent_config_dict": self.on_prem_config.agent_config_dict,
-                "override_agent_config_list": self.on_prem_config.override_agent_config_list,
-                "tools_config_list": self.on_prem_config.tools_config_list,
-                "post_call_transcription_webhook_url": self.on_prem_config.post_call_transcription_webhook_url,
-                "post_call_audio_webhook_url": self.on_prem_config.post_call_audio_webhook_url,
-                "prompt_knowledge_base": self.on_prem_config.prompt_knowledge_base,
-            }
-        )
+        message = {
+            "type": "enclave_setup_config",
+            "agent_config_dict": self.on_prem_config.agent_config_dict,
+            "override_agent_config_list": self.on_prem_config.override_agent_config_list,
+            "tools_config_list": self.on_prem_config.tools_config_list,
+            "post_call_transcription_webhook_url": self.on_prem_config.post_call_transcription_webhook_url,
+            "post_call_audio_webhook_url": self.on_prem_config.post_call_audio_webhook_url,
+            "prompt_knowledge_base": self.on_prem_config.prompt_knowledge_base,
+        }
+        if self.on_prem_config.post_call_transcription_webhook is not None:
+            message["post_call_transcription_webhook"] = (
+                self.on_prem_config.post_call_transcription_webhook.to_dict()
+            )
+        if self.on_prem_config.post_call_audio_webhook is not None:
+            message["post_call_audio_webhook"] = (
+                self.on_prem_config.post_call_audio_webhook.to_dict()
+            )
+        return json.dumps(message)
 
     def _create_initiation_message(self):
         return json.dumps(

--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -383,11 +383,8 @@ class OnPremInitiationData:
         post_call_transcription_webhook: Optional[PostCallWebhookConfig] = None,
         post_call_audio_webhook: Optional[PostCallWebhookConfig] = None,
     ):
-        # The orchestrator rejects the connection when both the legacy URL field
-        # and its typed counterpart are set; fail here with a clearer error. The
-        # checks mirror the orchestrator's: typed field compared against None,
-        # legacy URL by truthiness. An empty legacy URL counts as absent on both
-        # sides (the typed config wins), so it must not raise here.
+        # Fail early: the server rejects the connection when both forms are set.
+        # An empty legacy URL counts as unset server-side, hence truthiness here.
         if post_call_transcription_webhook is not None and post_call_transcription_webhook_url:
             raise ValueError(
                 "Set either post_call_transcription_webhook or post_call_transcription_webhook_url, not both."

--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -352,8 +352,10 @@ class ConversationInitiationData:
 class PostCallWebhookConfig:
     """Post-call webhook destination for on-prem deployments.
 
-    When ``hmac_secret`` is set (16 characters minimum), each delivery carries an
-    ``ElevenLabs-Signature`` header: ``t=<unix_ts>,v0=<hex hmac_sha256(secret, "{ts}.{body}")>``.
+    When ``hmac_secret`` is set, each delivery carries an ``ElevenLabs-Signature``
+    header: ``t=<unix_ts>,v0=<hex hmac_sha256(secret, "{ts}.{body}")>``. The
+    orchestrator enforces a 16-character minimum on the secret and rejects the
+    connection at setup otherwise.
     """
 
     url: str
@@ -382,12 +384,14 @@ class OnPremInitiationData:
         post_call_audio_webhook: Optional[PostCallWebhookConfig] = None,
     ):
         # The orchestrator rejects the connection when both the legacy URL field
-        # and its typed counterpart are set; fail here with a clearer error.
-        if post_call_transcription_webhook and post_call_transcription_webhook_url:
+        # and its typed counterpart are set; fail here with a clearer error. The
+        # checks mirror the orchestrator's: typed field compared against None,
+        # legacy URL by truthiness.
+        if post_call_transcription_webhook is not None and post_call_transcription_webhook_url:
             raise ValueError(
                 "Set either post_call_transcription_webhook or post_call_transcription_webhook_url, not both."
             )
-        if post_call_audio_webhook and post_call_audio_webhook_url:
+        if post_call_audio_webhook is not None and post_call_audio_webhook_url:
             raise ValueError(
                 "Set either post_call_audio_webhook or post_call_audio_webhook_url, not both."
             )

--- a/tests/test_convai_on_prem.py
+++ b/tests/test_convai_on_prem.py
@@ -1,0 +1,101 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from elevenlabs.conversational_ai.conversation import (
+    AudioInterface,
+    Conversation,
+    OnPremInitiationData,
+    PostCallWebhookConfig,
+)
+
+
+class MockAudioInterface(AudioInterface):
+    def start(self, input_callback):
+        self.input_callback = input_callback
+
+    def stop(self):
+        pass
+
+    def output(self, audio):
+        pass
+
+    def interrupt(self):
+        pass
+
+
+def _make_conversation(on_prem_config: OnPremInitiationData) -> Conversation:
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    return Conversation(
+        client=mock_client,
+        agent_id="",
+        requires_auth=False,
+        audio_interface=MockAudioInterface(),
+        on_prem_config=on_prem_config,
+    )
+
+
+def test_post_call_webhook_config_to_dict():
+    assert PostCallWebhookConfig(url="https://example.com/hook").to_dict() == {"url": "https://example.com/hook"}
+    assert PostCallWebhookConfig(url="https://example.com/hook", hmac_secret="0123456789abcdef").to_dict() == {
+        "url": "https://example.com/hook",
+        "hmac_secret": "0123456789abcdef",
+    }
+
+
+def test_on_prem_initiation_message_includes_typed_webhooks():
+    conversation = _make_conversation(
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            post_call_transcription_webhook=PostCallWebhookConfig(
+                url="https://example.com/transcript", hmac_secret="0123456789abcdef"
+            ),
+            post_call_audio_webhook=PostCallWebhookConfig(url="https://example.com/audio"),
+        )
+    )
+
+    message = json.loads(conversation._create_on_prem_initiation_message())
+
+    assert message["type"] == "enclave_setup_config"
+    assert message["post_call_transcription_webhook"] == {
+        "url": "https://example.com/transcript",
+        "hmac_secret": "0123456789abcdef",
+    }
+    assert message["post_call_audio_webhook"] == {"url": "https://example.com/audio"}
+    assert message["post_call_transcription_webhook_url"] is None
+    assert message["post_call_audio_webhook_url"] is None
+
+
+def test_on_prem_initiation_message_omits_typed_webhooks_when_unset():
+    conversation = _make_conversation(
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            post_call_transcription_webhook_url="https://example.com/transcript",
+        )
+    )
+
+    message = json.loads(conversation._create_on_prem_initiation_message())
+
+    assert "post_call_transcription_webhook" not in message
+    assert "post_call_audio_webhook" not in message
+    assert message["post_call_transcription_webhook_url"] == "https://example.com/transcript"
+
+
+@pytest.mark.parametrize(
+    ("legacy_kwarg", "typed_kwarg"),
+    [
+        ("post_call_transcription_webhook_url", "post_call_transcription_webhook"),
+        ("post_call_audio_webhook_url", "post_call_audio_webhook"),
+    ],
+)
+def test_on_prem_initiation_data_rejects_legacy_and_typed_for_same_webhook(legacy_kwarg: str, typed_kwarg: str):
+    with pytest.raises(ValueError, match="not both"):
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            **{
+                legacy_kwarg: "https://example.com/hook",
+                typed_kwarg: PostCallWebhookConfig(url="https://example.com/hook"),
+            },
+        )

--- a/tests/test_convai_on_prem.py
+++ b/tests/test_convai_on_prem.py
@@ -33,6 +33,9 @@ def _make_conversation(on_prem_config: OnPremInitiationData) -> Conversation:
         agent_id="",
         requires_auth=False,
         audio_interface=MockAudioInterface(),
+        # Mocked so the constructor's client_tools.start() does not spawn a real
+        # event-loop thread; these tests only exercise message serialization.
+        client_tools=MagicMock(),
         on_prem_config=on_prem_config,
     )
 

--- a/tests/test_convai_on_prem.py
+++ b/tests/test_convai_on_prem.py
@@ -83,19 +83,19 @@ def test_on_prem_initiation_message_omits_typed_webhooks_when_unset():
     assert message["post_call_transcription_webhook_url"] == "https://example.com/transcript"
 
 
-@pytest.mark.parametrize(
-    ("legacy_kwarg", "typed_kwarg"),
-    [
-        ("post_call_transcription_webhook_url", "post_call_transcription_webhook"),
-        ("post_call_audio_webhook_url", "post_call_audio_webhook"),
-    ],
-)
-def test_on_prem_initiation_data_rejects_legacy_and_typed_for_same_webhook(legacy_kwarg: str, typed_kwarg: str):
+def test_on_prem_initiation_data_rejects_legacy_and_typed_transcription_webhook():
     with pytest.raises(ValueError, match="not both"):
         OnPremInitiationData(
             on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
-            **{
-                legacy_kwarg: "https://example.com/hook",
-                typed_kwarg: PostCallWebhookConfig(url="https://example.com/hook"),
-            },
+            post_call_transcription_webhook_url="https://example.com/hook",
+            post_call_transcription_webhook=PostCallWebhookConfig(url="https://example.com/hook"),
+        )
+
+
+def test_on_prem_initiation_data_rejects_legacy_and_typed_audio_webhook():
+    with pytest.raises(ValueError, match="not both"):
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            post_call_audio_webhook_url="https://example.com/hook",
+            post_call_audio_webhook=PostCallWebhookConfig(url="https://example.com/hook"),
         )


### PR DESCRIPTION
Adds typed post-call webhook config with optional HMAC signing to `OnPremInitiationData`.

## Why

The in-VPC orchestrator now supports HMAC-signed post-call webhooks (elevenlabs/xi#40783), configured via new setup-message fields the SDK could not emit.

## How

- New `PostCallWebhookConfig` dataclass with `url` and optional `hmac_secret`
- `OnPremInitiationData` accepts `post_call_transcription_webhook` and `post_call_audio_webhook`
- Setup message emits the typed fields only when set
- Legacy `*_webhook_url` params unchanged (always unsigned)
- Setting legacy and typed for the same webhook raises `ValueError` client-side (server would reject with close code 3001)

## Testing

- New `tests/test_convai_on_prem.py`: `to_dict` shapes, message emission, both-fields `ValueError` (5 passing)
- Existing convai suites pass (20/20)
- Emitted message cross-verified against the orchestrator parser in elevenlabs/xi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK API and setup-message fields; legacy webhook URLs unchanged. HMAC secrets are passed through configuration only—no new signing logic in the SDK.
> 
> **Overview**
> Adds **`PostCallWebhookConfig`** (`url` + optional `hmac_secret`) so on-prem setups can request **HMAC-signed** post-call deliveries via the orchestrator’s new setup fields.
> 
> **`OnPremInitiationData`** now accepts `post_call_transcription_webhook` and `post_call_audio_webhook` alongside the existing `*_webhook_url` strings. Mixing legacy URL and typed config for the same webhook raises **`ValueError`** client-side. **`_create_on_prem_initiation_message`** includes the typed objects only when set; legacy URL fields stay unchanged (unsigned).
> 
> New **`tests/test_convai_on_prem.py`** covers serialization, omission when unset, and mutual-exclusion validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ebecde44ebfd91bd7fed1ee2ab1b5cdf54714a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->