### PR TITLE
fix: avoid blocking AsyncConversation startup

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -1049,7 +1049,10 @@ class AsyncConversation(BaseConversation):
 
         Will run in background task until `end_session` is called.
         """
-        ws_url = self._get_signed_url() if self.requires_auth else self._get_wss_url()
+        if self.requires_auth:
+            ws_url = await asyncio.get_running_loop().run_in_executor(None, self._get_signed_url)
+        else:
+            ws_url = self._get_wss_url()
         self._task = asyncio.create_task(self._run(ws_url))
 
     async def end_session(self):

--- a/tests/test_async_convai.py
+++ b/tests/test_async_convai.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -142,6 +143,23 @@ async def test_async_conversation_with_auth():
 
     # Assertions
     mock_client.conversational_ai.conversations.get_signed_url.assert_called_once_with(agent_id=TEST_AGENT_ID, environment=None)
+
+
+@pytest.mark.asyncio
+async def test_async_conversation_gets_signed_url_off_event_loop():
+    conversation = AsyncConversation(client=MagicMock(), agent_id=TEST_AGENT_ID, requires_auth=True)
+    event_loop_thread = threading.get_ident()
+
+    def get_signed_url():
+        assert threading.get_ident() != event_loop_thread
+        return "wss://signed.url"
+
+    with patch.object(conversation, "_get_signed_url", side_effect=get_signed_url), patch.object(
+        conversation, "_run", new=AsyncMock()
+    ):
+        await conversation.start_session()
+        await conversation.wait_for_session_end()
+        await conversation.end_session()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`AsyncConversation.start_session()` currently performs the authenticated signed-URL request synchronously on the event-loop thread. Run that existing synchronous helper in the loop executor so authenticated startup does not pause unrelated async work.

Closes #811.

## Tests

- Added a regression test that verifies signed-URL resolution runs outside the event-loop thread.
- `python -m pytest tests/test_async_convai.py -q` on Python 3.8.20 — 10 passed
- `python tests/verify_types.py` — 1,570 type files passed
- `mypy .` — 2,246 source files passed
- `ruff check tests/test_async_convai.py`