### PR TITLE
fix: stop realtime TTS after final message

### DIFF
--- a/src/elevenlabs/realtime_tts.py
+++ b/src/elevenlabs/realtime_tts.py
@@ -139,6 +139,8 @@ class RealtimeTextToSpeechClient(TextToSpeechClient):
                     data = json.loads(socket.recv())
                     if "audio" in data and data["audio"]:
                         yield base64.b64decode(data["audio"])  # type: ignore
+                    if data.get("isFinal"):
+                        break
             except websockets.exceptions.ConnectionClosed as ce:
                 if "message" in data:
                     raise ApiError(body=data, status_code=ce.code)

--- a/tests/test_realtime_tts.py
+++ b/tests/test_realtime_tts.py
@@ -1,0 +1,38 @@
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+from elevenlabs.realtime_tts import RealtimeTextToSpeechClient
+
+
+def test_convert_realtime_stops_after_final_message():
+    audio = b"final audio"
+    socket = MagicMock()
+    socket.__enter__.return_value = socket
+    socket.recv.side_effect = [
+        json.dumps(
+            {
+                "audio": base64.b64encode(audio).decode(),
+                "isFinal": True,
+            }
+        ),
+        AssertionError("convert_realtime read past the final message"),
+    ]
+
+    client = object.__new__(RealtimeTextToSpeechClient)
+    client._client_wrapper = MagicMock()
+    client._client_wrapper.get_headers.return_value = {}
+    client._ws_base_url = "wss://api.elevenlabs.io"
+
+    with patch("elevenlabs.realtime_tts.connect", return_value=socket):
+        result = list(
+            client.convert_realtime(
+                "voice-id",
+                text=iter(()),
+                model_id="eleven_flash_v2_5",
+                voice_settings=None,
+            )
+        )
+
+    assert result == [audio]
+    assert socket.recv.call_count == 1


### PR DESCRIPTION
## summary

- stop the realtime TTS drain loop when the server sends isFinal
- yield audio from the final frame before closing the generator
- add a regression test that fails on any extra socket read

This changes only realtime_tts.py and tests, both of which are hand maintained according to .fernignore.

## testing

- Python compilation for the changed source and test files
- focused standard library harness using the actual edited method
- git diff check

Pytest and Ruff are not installed in the local workspace, so the repository CI will run those checks.

Fixes #569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to hand-maintained realtime streaming logic with a focused unit test; no auth or data-model impact.
> 
> **Overview**
> Fixes **`convert_realtime`** so the post-input WebSocket drain loop exits when the API marks the stream complete with **`isFinal`**, instead of reading until the connection closes.
> 
> Audio on the final frame is still decoded and yielded before the generator stops, which avoids hanging or extra **`recv`** calls after generation ends.
> 
> Adds **`test_convert_realtime_stops_after_final_message`** to assert a single read and that no further socket reads occur after the final message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c52630b339f78294dd327c5c7159779a8dc129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->