### PR TITLE
Add extra_setup_config escape hatch for on-prem setup message

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -371,6 +371,24 @@ class PostCallWebhookConfig:
 class OnPremInitiationData:
     """Configuration options for the Conversation in on-prem mode."""
 
+    #: Keys this class writes into the setup message itself. `extra_setup_config`
+    #: may not contain them, so an escape-hatch value can never silently defeat
+    #: the validation on the typed fields.
+    _RESERVED_SETUP_KEYS = frozenset(
+        {
+            "type",
+            "agent_config_dict",
+            "override_agent_config_list",
+            "tools_config_list",
+            "post_call_transcription_webhook_url",
+            "post_call_audio_webhook_url",
+            "post_call_transcription_webhook",
+            "post_call_audio_webhook",
+            "prompt_knowledge_base",
+            "bedrock_inference_profile",
+        }
+    )
+
     def __init__(
         self,
         on_prem_conversation_url: str,
@@ -382,7 +400,23 @@ class OnPremInitiationData:
         prompt_knowledge_base: Optional[List[str]] = None,
         post_call_transcription_webhook: Optional[PostCallWebhookConfig] = None,
         post_call_audio_webhook: Optional[PostCallWebhookConfig] = None,
+        bedrock_inference_profile: Optional[str] = None,
+        extra_setup_config: Optional[dict] = None,
     ):
+        """On-prem (in-VPC) conversation setup.
+
+        Args:
+            on_prem_conversation_url: WebSocket URL of the on-prem conversation
+                endpoint. Used verbatim, so any query parameters the deployment
+                supports (e.g. ``?conversation_id=...``) can be set here.
+            bedrock_inference_profile: Bedrock cross-region inference profile to
+                route Claude models through. ``"global"`` selects the
+                ``global.anthropic.*`` profiles where available; the server
+                defaults to ``"us"`` when unset.
+            extra_setup_config: Escape hatch for setup-message fields this SDK
+                version does not model yet. Merged into the message as-is. Keys
+                that collide with the typed fields above are rejected.
+        """
         # Fail early: the server rejects the connection when both forms are set.
         # An empty legacy URL counts as unset server-side, hence truthiness here.
         if post_call_transcription_webhook is not None and post_call_transcription_webhook_url:
@@ -393,6 +427,15 @@ class OnPremInitiationData:
             raise ValueError(
                 "Set either post_call_audio_webhook or post_call_audio_webhook_url, not both."
             )
+        if extra_setup_config is not None:
+            if not isinstance(extra_setup_config, dict):
+                raise ValueError("extra_setup_config must be a dict.")
+            reserved = sorted(self._RESERVED_SETUP_KEYS.intersection(extra_setup_config))
+            if reserved:
+                raise ValueError(
+                    f"extra_setup_config may not override {', '.join(reserved)}; "
+                    "pass these as named arguments instead."
+                )
         self.on_prem_conversation_url = on_prem_conversation_url
         self.post_call_transcription_webhook_url = post_call_transcription_webhook_url
         self.post_call_audio_webhook_url = post_call_audio_webhook_url
@@ -402,6 +445,8 @@ class OnPremInitiationData:
         self.prompt_knowledge_base = prompt_knowledge_base
         self.post_call_transcription_webhook = post_call_transcription_webhook
         self.post_call_audio_webhook = post_call_audio_webhook
+        self.bedrock_inference_profile = bedrock_inference_profile
+        self.extra_setup_config = dict(extra_setup_config) if extra_setup_config else {}
 
 
 @dataclass
@@ -479,15 +524,22 @@ class BaseConversation:
         return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(existing_params, quote_via=urllib.parse.quote)))
 
     def _create_on_prem_initiation_message(self):
-        message = {
-            "type": "enclave_setup_config",
-            "agent_config_dict": self.on_prem_config.agent_config_dict,
-            "override_agent_config_list": self.on_prem_config.override_agent_config_list,
-            "tools_config_list": self.on_prem_config.tools_config_list,
-            "post_call_transcription_webhook_url": self.on_prem_config.post_call_transcription_webhook_url,
-            "post_call_audio_webhook_url": self.on_prem_config.post_call_audio_webhook_url,
-            "prompt_knowledge_base": self.on_prem_config.prompt_knowledge_base,
-        }
+        # Extras go in first; the reserved-key check in OnPremInitiationData
+        # guarantees the typed fields below cannot be clobbering anything.
+        message = dict(self.on_prem_config.extra_setup_config)
+        message.update(
+            {
+                "type": "enclave_setup_config",
+                "agent_config_dict": self.on_prem_config.agent_config_dict,
+                "override_agent_config_list": self.on_prem_config.override_agent_config_list,
+                "tools_config_list": self.on_prem_config.tools_config_list,
+                "post_call_transcription_webhook_url": self.on_prem_config.post_call_transcription_webhook_url,
+                "post_call_audio_webhook_url": self.on_prem_config.post_call_audio_webhook_url,
+                "prompt_knowledge_base": self.on_prem_config.prompt_knowledge_base,
+            }
+        )
+        if self.on_prem_config.bedrock_inference_profile is not None:
+            message["bedrock_inference_profile"] = self.on_prem_config.bedrock_inference_profile
         if self.on_prem_config.post_call_transcription_webhook is not None:
             message["post_call_transcription_webhook"] = (
                 self.on_prem_config.post_call_transcription_webhook.to_dict()

--- a/tests/test_convai_on_prem.py
+++ b/tests/test_convai_on_prem.py
@@ -102,3 +102,63 @@ def test_on_prem_initiation_data_rejects_legacy_and_typed_audio_webhook():
             post_call_audio_webhook_url="https://example.com/hook",
             post_call_audio_webhook=PostCallWebhookConfig(url="https://example.com/hook"),
         )
+
+
+def test_on_prem_initiation_message_includes_bedrock_inference_profile():
+    conversation = _make_conversation(
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            bedrock_inference_profile="global",
+        )
+    )
+
+    message = json.loads(conversation._create_on_prem_initiation_message())
+
+    assert message["bedrock_inference_profile"] == "global"
+
+
+def test_on_prem_initiation_message_omits_bedrock_inference_profile_when_unset():
+    conversation = _make_conversation(
+        OnPremInitiationData(on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation")
+    )
+
+    message = json.loads(conversation._create_on_prem_initiation_message())
+
+    assert "bedrock_inference_profile" not in message
+
+
+def test_on_prem_initiation_message_merges_extra_setup_config():
+    conversation = _make_conversation(
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            prompt_knowledge_base=["kb entry"],
+            extra_setup_config={"some_future_field": {"nested": 1}, "another": "value"},
+        )
+    )
+
+    message = json.loads(conversation._create_on_prem_initiation_message())
+
+    assert message["some_future_field"] == {"nested": 1}
+    assert message["another"] == "value"
+    # Typed fields still serialize as before.
+    assert message["type"] == "enclave_setup_config"
+    assert message["prompt_knowledge_base"] == ["kb entry"]
+
+
+def test_on_prem_initiation_data_rejects_reserved_keys_in_extra_setup_config():
+    with pytest.raises(ValueError, match="prompt_knowledge_base"):
+        OnPremInitiationData(
+            on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+            extra_setup_config={"prompt_knowledge_base": ["sneaky"]},
+        )
+
+
+def test_on_prem_initiation_data_copies_extra_setup_config():
+    extra = {"some_future_field": 1}
+    config = OnPremInitiationData(
+        on_prem_conversation_url="ws://localhost:8000/sagemaker/convai/conversation",
+        extra_setup_config=extra,
+    )
+    extra["mutated_after_construction"] = True
+
+    assert config.extra_setup_config == {"some_future_field": 1}


### PR DESCRIPTION
Adds missing parameter for the on-prem API + a "misc" parameter for supplying anything extra so we don't run into this again.

In the future we will auto-generate with with OpenAPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b71319d52213a1d8baf849b260d90078b4bbe6b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->