### PR TITLE
fix: preserve ConvAI audio replies after interruptions

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -527,7 +527,7 @@ class BaseConversation:
 
         elif message["type"] == "audio":
             event = message["audio_event"]
-            if int(event["event_id"]) <= self._last_interrupt_id:
+            if int(event["event_id"]) < self._last_interrupt_id:
                 return
             audio = base64.b64decode(event["audio_base_64"])
             message_handler.handle_audio_output(audio)
@@ -597,7 +597,7 @@ class BaseConversation:
 
         elif message["type"] == "audio":
             event = message["audio_event"]
-            if int(event["event_id"]) <= self._last_interrupt_id:
+            if int(event["event_id"]) < self._last_interrupt_id:
                 return
             audio = base64.b64decode(event["audio_base_64"])
             await message_handler.handle_audio_output(audio)

--- a/tests/test_convai_audio_events.py
+++ b/tests/test_convai_audio_events.py
@@ -1,0 +1,76 @@
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from elevenlabs.conversational_ai.conversation import BaseConversation
+
+
+def _conversation_with_interrupt(event_id: int) -> BaseConversation:
+    conversation = BaseConversation.__new__(BaseConversation)
+    conversation._last_interrupt_id = event_id
+    return conversation
+
+
+def _audio_message(event_id: int) -> dict:
+    return {
+        "type": "audio",
+        "audio_event": {
+            "event_id": str(event_id),
+            "audio_base_64": base64.b64encode(b"reply audio").decode("ascii"),
+        },
+    }
+
+
+def _interruption_message(event_id: int) -> dict:
+    return {
+        "type": "interruption",
+        "interruption_event": {"event_id": str(event_id)},
+    }
+
+
+def test_sync_conversation_keeps_audio_with_interruption_event_id():
+    conversation = _conversation_with_interrupt(0)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+
+    conversation._handle_message_core(_interruption_message(87), message_handler)
+    conversation._handle_message_core(_audio_message(87), message_handler)
+
+    message_handler.handle_audio_output.assert_called_once_with(b"reply audio")
+
+
+def test_sync_conversation_discards_audio_older_than_interruption():
+    conversation = _conversation_with_interrupt(87)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+
+    conversation._handle_message_core(_audio_message(86), message_handler)
+
+    message_handler.handle_audio_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_conversation_keeps_audio_with_interruption_event_id():
+    conversation = _conversation_with_interrupt(0)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+    message_handler.handle_audio_output = AsyncMock()
+    message_handler.handle_interruption = AsyncMock()
+
+    await conversation._handle_message_core_async(_interruption_message(87), message_handler)
+    await conversation._handle_message_core_async(_audio_message(87), message_handler)
+
+    message_handler.handle_audio_output.assert_awaited_once_with(b"reply audio")
+
+
+@pytest.mark.asyncio
+async def test_async_conversation_discards_audio_older_than_interruption():
+    conversation = _conversation_with_interrupt(87)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+    message_handler.handle_audio_output = AsyncMock()
+
+    await conversation._handle_message_core_async(_audio_message(86), message_handler)
+
+    message_handler.handle_audio_output.assert_not_awaited()

--- a/tests/test_convai_audio_events.py
+++ b/tests/test_convai_audio_events.py
@@ -29,7 +29,7 @@ def _interruption_message(event_id: int) -> dict:
     }
 
 
-def test_sync_conversation_keeps_audio_with_interruption_event_id():
+def test_sync_conversation_keeps_audio_equal_to_interruption():
     conversation = _conversation_with_interrupt(0)
     message_handler = MagicMock()
     message_handler.callback_audio_alignment = None
@@ -40,7 +40,18 @@ def test_sync_conversation_keeps_audio_with_interruption_event_id():
     message_handler.handle_audio_output.assert_called_once_with(b"reply audio")
 
 
-def test_sync_conversation_discards_audio_older_than_interruption():
+def test_sync_conversation_keeps_audio_newer_than_interruption():
+    conversation = _conversation_with_interrupt(0)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+
+    conversation._handle_message_core(_interruption_message(87), message_handler)
+    conversation._handle_message_core(_audio_message(88), message_handler)
+
+    message_handler.handle_audio_output.assert_called_once_with(b"reply audio")
+
+
+def test_sync_conversation_drops_audio_older_than_interruption():
     conversation = _conversation_with_interrupt(87)
     message_handler = MagicMock()
     message_handler.callback_audio_alignment = None
@@ -51,7 +62,7 @@ def test_sync_conversation_discards_audio_older_than_interruption():
 
 
 @pytest.mark.asyncio
-async def test_async_conversation_keeps_audio_with_interruption_event_id():
+async def test_async_conversation_keeps_audio_equal_to_interruption():
     conversation = _conversation_with_interrupt(0)
     message_handler = MagicMock()
     message_handler.callback_audio_alignment = None
@@ -65,7 +76,21 @@ async def test_async_conversation_keeps_audio_with_interruption_event_id():
 
 
 @pytest.mark.asyncio
-async def test_async_conversation_discards_audio_older_than_interruption():
+async def test_async_conversation_keeps_audio_newer_than_interruption():
+    conversation = _conversation_with_interrupt(0)
+    message_handler = MagicMock()
+    message_handler.callback_audio_alignment = None
+    message_handler.handle_audio_output = AsyncMock()
+    message_handler.handle_interruption = AsyncMock()
+
+    await conversation._handle_message_core_async(_interruption_message(87), message_handler)
+    await conversation._handle_message_core_async(_audio_message(88), message_handler)
+
+    message_handler.handle_audio_output.assert_awaited_once_with(b"reply audio")
+
+
+@pytest.mark.asyncio
+async def test_async_conversation_drops_audio_older_than_interruption():
     conversation = _conversation_with_interrupt(87)
     message_handler = MagicMock()
     message_handler.callback_audio_alignment = None


### PR DESCRIPTION
## Summary

Fixes #829.

ConvAI can send the interruption event and the audio events for the resulting reply with the same `event_id`. The sync and async handlers currently discard those audio events because they reject IDs less than or equal to the last interruption. This changes both checks to reject only older IDs, so equal-ID reply audio is delivered while stale audio remains filtered.

## Reference

This matches the official JS client (@elevenlabs/client), which plays audio when `lastInterruptTimestamp <= audio_event.event_id` and starts `lastInterruptTimestamp` at 0 - in other words, drop strictly older audio only. The Python gate now applies the same rule on `_last_interrupt_id`, including the edge case where an audio event carries id 0 before any interruption.

## Changes

- Update the sync and async audio-event guards in the hand-maintained ConvAI wrapper.
- Add regression coverage for equal-ID reply audio and older audio events in both paths.

## Testing

- `PYTHONPATH=src uv run --with pytest --with pytest-asyncio --with websockets pytest tests/test_convai.py tests/test_async_convai.py tests/test_convai_audio_events.py -q`
- `PYTHONPATH=src uv run --no-project python3 -m compileall -q src/elevenlabs/conversational_ai/conversation.py tests/test_convai_audio_events.py`
- Offline suite: `171 passed` after excluding the existing API-backed integration tests, which require `ELEVENLABS_API_KEY`.
- `uv run --with ruff ruff check tests/test_convai_audio_events.py`
- `git diff --check`

The repository README notes that direct SDK changes are proof-of-concept contributions because most of the SDK is generated by Fern; this PR is limited to files listed in `.fernignore`.

## Follow-up (review feedback)

- Added the strictly-newer audio case (88 after interrupt 87) for both sync and async paths. The previous set only pinned `=` and `<`, so a rule that had regressed to equality-only would have slipped through.
- Renamed the tests around the drop rule itself so the parity with the JS client is legible to the next reader.
- Focused run: `pytest tests/test_convai_audio_events.py -q` - 6 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavioral fix in ConvAI message handling with targeted unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes dropped ConvAI reply audio when the server sends **interruption** and **audio** events sharing the same `event_id`.
> 
> In `conversation.py`, sync and async audio handlers now skip only events with `event_id` **strictly less than** `_last_interrupt_id` (was `<=`), so post-interruption reply audio at the same ID is played while pre-interruption audio is still filtered.
> 
> Adds `tests/test_convai_audio_events.py` with sync/async regression tests for equal-ID, newer, and older audio relative to an interruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318ad071bac196fc816c8f72c723e771b0f50288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->