### PR TITLE
fix: add callback_interruption to Conversation/AsyncConversation

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -413,6 +413,14 @@ class AudioEventAlignment:
     char_durations_ms: List[int]
 
 
+@dataclass
+class InterruptionEvent:
+    """Data describing why and where an interruption occurred."""
+
+    event_id: int
+    reason: Optional[str] = None
+
+
 class BaseConversation:
     """Base class for conversation implementations with shared parameters and logic."""
 
@@ -572,7 +580,8 @@ class BaseConversation:
         elif message["type"] == "interruption":
             event = message["interruption_event"]
             self._last_interrupt_id = int(event["event_id"])
-            message_handler.handle_interruption(event)
+            interruption = InterruptionEvent(event_id=self._last_interrupt_id, reason=event.get("reason"))
+            message_handler.handle_interruption(interruption)
 
         elif message["type"] == "ping":
             event = message["ping_event"]
@@ -642,7 +651,8 @@ class BaseConversation:
         elif message["type"] == "interruption":
             event = message["interruption_event"]
             self._last_interrupt_id = int(event["event_id"])
-            await message_handler.handle_interruption(event)
+            interruption = InterruptionEvent(event_id=self._last_interrupt_id, reason=event.get("reason"))
+            await message_handler.handle_interruption(interruption)
 
         elif message["type"] == "ping":
             event = message["ping_event"]
@@ -667,7 +677,7 @@ class Conversation(BaseConversation):
     callback_user_transcript: Optional[Callable[[str], None]]
     callback_latency_measurement: Optional[Callable[[int], None]]
     callback_audio_alignment: Optional[Callable[[AudioEventAlignment], None]]
-    callback_interruption: Optional[Callable[[dict], None]]
+    callback_interruption: Optional[Callable[[InterruptionEvent], None]]
     callback_end_session: Optional[Callable]
 
     _thread: Optional[threading.Thread]
@@ -690,7 +700,7 @@ class Conversation(BaseConversation):
         callback_user_transcript: Optional[Callable[[str], None]] = None,
         callback_latency_measurement: Optional[Callable[[int], None]] = None,
         callback_audio_alignment: Optional[Callable[[AudioEventAlignment], None]] = None,
-        callback_interruption: Optional[Callable[[dict], None]] = None,
+        callback_interruption: Optional[Callable[[InterruptionEvent], None]] = None,
         callback_end_session: Optional[Callable] = None,
         on_prem_config: Optional[OnPremInitiationData] = None,
         environment: Optional[str] = None,
@@ -716,8 +726,8 @@ class Conversation(BaseConversation):
             callback_user_transcript: Callback for user transcripts.
             callback_latency_measurement: Callback for latency measurements (in milliseconds).
             callback_audio_alignment: Callback for audio alignment data with character-level timing.
-            callback_interruption: Callback for interruption events, invoked with the raw
-                interruption event dict. Fires in addition to interrupting the audio
+            callback_interruption: Callback for interruption events, invoked with an
+                InterruptionEvent. Fires in addition to interrupting the audio
                 interface (if one is attached).
             environment: The environment to use. Defaults to "production" on the server.
         """
@@ -977,7 +987,7 @@ class AsyncConversation(BaseConversation):
     callback_user_transcript: Optional[Callable[[str], Awaitable[None]]]
     callback_latency_measurement: Optional[Callable[[int], Awaitable[None]]]
     callback_audio_alignment: Optional[Callable[[AudioEventAlignment], Awaitable[None]]]
-    callback_interruption: Optional[Callable[[dict], Awaitable[None]]]
+    callback_interruption: Optional[Callable[[InterruptionEvent], Awaitable[None]]]
     callback_end_session: Optional[Callable[[], Awaitable[None]]]
 
     _task: Optional[asyncio.Task]
@@ -1000,7 +1010,7 @@ class AsyncConversation(BaseConversation):
         callback_user_transcript: Optional[Callable[[str], Awaitable[None]]] = None,
         callback_latency_measurement: Optional[Callable[[int], Awaitable[None]]] = None,
         callback_audio_alignment: Optional[Callable[[AudioEventAlignment], Awaitable[None]]] = None,
-        callback_interruption: Optional[Callable[[dict], Awaitable[None]]] = None,
+        callback_interruption: Optional[Callable[[InterruptionEvent], Awaitable[None]]] = None,
         callback_end_session: Optional[Callable[[], Awaitable[None]]] = None,
         on_prem_config: Optional[OnPremInitiationData] = None,
         environment: Optional[str] = None,
@@ -1026,8 +1036,8 @@ class AsyncConversation(BaseConversation):
             callback_user_transcript: Async callback for user transcripts.
             callback_latency_measurement: Async callback for latency measurements (in milliseconds).
             callback_audio_alignment: Async callback for audio alignment data with character-level timing.
-            callback_interruption: Async callback for interruption events, invoked with the raw
-                interruption event dict. Fires in addition to interrupting the audio
+            callback_interruption: Async callback for interruption events, invoked with an
+                InterruptionEvent. Fires in addition to interrupting the audio
                 interface (if one is attached).
             callback_end_session: Async callback for when session ends.
             environment: The environment to use. Defaults to "production" on the server.

--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -572,7 +572,7 @@ class BaseConversation:
         elif message["type"] == "interruption":
             event = message["interruption_event"]
             self._last_interrupt_id = int(event["event_id"])
-            message_handler.handle_interruption()
+            message_handler.handle_interruption(event)
 
         elif message["type"] == "ping":
             event = message["ping_event"]
@@ -642,7 +642,7 @@ class BaseConversation:
         elif message["type"] == "interruption":
             event = message["interruption_event"]
             self._last_interrupt_id = int(event["event_id"])
-            await message_handler.handle_interruption()
+            await message_handler.handle_interruption(event)
 
         elif message["type"] == "ping":
             event = message["ping_event"]
@@ -667,6 +667,7 @@ class Conversation(BaseConversation):
     callback_user_transcript: Optional[Callable[[str], None]]
     callback_latency_measurement: Optional[Callable[[int], None]]
     callback_audio_alignment: Optional[Callable[[AudioEventAlignment], None]]
+    callback_interruption: Optional[Callable[[dict], None]]
     callback_end_session: Optional[Callable]
 
     _thread: Optional[threading.Thread]
@@ -689,6 +690,7 @@ class Conversation(BaseConversation):
         callback_user_transcript: Optional[Callable[[str], None]] = None,
         callback_latency_measurement: Optional[Callable[[int], None]] = None,
         callback_audio_alignment: Optional[Callable[[AudioEventAlignment], None]] = None,
+        callback_interruption: Optional[Callable[[dict], None]] = None,
         callback_end_session: Optional[Callable] = None,
         on_prem_config: Optional[OnPremInitiationData] = None,
         environment: Optional[str] = None,
@@ -714,6 +716,9 @@ class Conversation(BaseConversation):
             callback_user_transcript: Callback for user transcripts.
             callback_latency_measurement: Callback for latency measurements (in milliseconds).
             callback_audio_alignment: Callback for audio alignment data with character-level timing.
+            callback_interruption: Callback for interruption events, invoked with the raw
+                interruption event dict. Fires in addition to interrupting the audio
+                interface (if one is attached).
             environment: The environment to use. Defaults to "production" on the server.
         """
 
@@ -736,6 +741,7 @@ class Conversation(BaseConversation):
         self.callback_user_transcript = callback_user_transcript
         self.callback_latency_measurement = callback_latency_measurement
         self.callback_audio_alignment = callback_audio_alignment
+        self.callback_interruption = callback_interruption
         self.callback_end_session = callback_end_session
 
         self._thread = None
@@ -912,6 +918,7 @@ class Conversation(BaseConversation):
                 self.callback_user_transcript = conversation.callback_user_transcript
                 self.callback_latency_measurement = conversation.callback_latency_measurement
                 self.callback_audio_alignment = conversation.callback_audio_alignment
+                self.callback_interruption = conversation.callback_interruption
 
             def handle_audio_output(self, audio):
                 if self.conversation.audio_interface is not None:
@@ -932,9 +939,11 @@ class Conversation(BaseConversation):
             def handle_user_transcript(self, transcript):
                 self.conversation.callback_user_transcript(transcript)
 
-            def handle_interruption(self):
+            def handle_interruption(self, event):
                 if self.conversation.audio_interface is not None:
                     self.conversation.audio_interface.interrupt()
+                if self.callback_interruption:
+                    self.callback_interruption(event)
 
             def handle_ping(self, event):
                 self.ws.send(
@@ -968,6 +977,7 @@ class AsyncConversation(BaseConversation):
     callback_user_transcript: Optional[Callable[[str], Awaitable[None]]]
     callback_latency_measurement: Optional[Callable[[int], Awaitable[None]]]
     callback_audio_alignment: Optional[Callable[[AudioEventAlignment], Awaitable[None]]]
+    callback_interruption: Optional[Callable[[dict], Awaitable[None]]]
     callback_end_session: Optional[Callable[[], Awaitable[None]]]
 
     _task: Optional[asyncio.Task]
@@ -990,6 +1000,7 @@ class AsyncConversation(BaseConversation):
         callback_user_transcript: Optional[Callable[[str], Awaitable[None]]] = None,
         callback_latency_measurement: Optional[Callable[[int], Awaitable[None]]] = None,
         callback_audio_alignment: Optional[Callable[[AudioEventAlignment], Awaitable[None]]] = None,
+        callback_interruption: Optional[Callable[[dict], Awaitable[None]]] = None,
         callback_end_session: Optional[Callable[[], Awaitable[None]]] = None,
         on_prem_config: Optional[OnPremInitiationData] = None,
         environment: Optional[str] = None,
@@ -1015,6 +1026,9 @@ class AsyncConversation(BaseConversation):
             callback_user_transcript: Async callback for user transcripts.
             callback_latency_measurement: Async callback for latency measurements (in milliseconds).
             callback_audio_alignment: Async callback for audio alignment data with character-level timing.
+            callback_interruption: Async callback for interruption events, invoked with the raw
+                interruption event dict. Fires in addition to interrupting the audio
+                interface (if one is attached).
             callback_end_session: Async callback for when session ends.
             environment: The environment to use. Defaults to "production" on the server.
         """
@@ -1038,6 +1052,7 @@ class AsyncConversation(BaseConversation):
         self.callback_user_transcript = callback_user_transcript
         self.callback_latency_measurement = callback_latency_measurement
         self.callback_audio_alignment = callback_audio_alignment
+        self.callback_interruption = callback_interruption
         self.callback_end_session = callback_end_session
 
         self._task = None
@@ -1220,6 +1235,7 @@ class AsyncConversation(BaseConversation):
                 self.callback_user_transcript = conversation.callback_user_transcript
                 self.callback_latency_measurement = conversation.callback_latency_measurement
                 self.callback_audio_alignment = conversation.callback_audio_alignment
+                self.callback_interruption = conversation.callback_interruption
 
             async def handle_audio_output(self, audio):
                 if self.conversation.audio_interface is not None:
@@ -1240,9 +1256,11 @@ class AsyncConversation(BaseConversation):
             async def handle_user_transcript(self, transcript):
                 await self.conversation.callback_user_transcript(transcript)
 
-            async def handle_interruption(self):
+            async def handle_interruption(self, event):
                 if self.conversation.audio_interface is not None:
                     await self.conversation.audio_interface.interrupt()
+                if self.callback_interruption:
+                    await self.callback_interruption(event)
 
             async def handle_ping(self, event):
                 await self.ws.send(

--- a/tests/test_async_convai.py
+++ b/tests/test_async_convai.py
@@ -567,3 +567,39 @@ async def test_async_interruption_without_callback_does_not_raise():
         await conversation.wait_for_session_end()
 
     assert audio_interface.interrupt_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_callback_interruption_defaults_reason_to_none():
+    """When the raw event has no 'reason' key, InterruptionEvent.reason falls back to None."""
+    mock_ws = create_mock_async_websocket(
+        [
+            {
+                "type": "conversation_initiation_metadata",
+                "conversation_initiation_metadata_event": {"conversation_id": TEST_CONVERSATION_ID},
+            },
+            {"type": "interruption", "interruption_event": {"event_id": 1}},
+        ]
+    )
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = AsyncMock()
+
+    conversation = AsyncConversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=None,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.websockets.connect") as mock_connect:
+        mock_connect.return_value.__aenter__.return_value = mock_ws
+
+        await conversation.start_session()
+        await asyncio.sleep(0.1)
+
+        await conversation.end_session()
+        await conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason=None))

--- a/tests/test_async_convai.py
+++ b/tests/test_async_convai.py
@@ -13,6 +13,9 @@ from elevenlabs.conversational_ai.conversation import (
 
 
 class MockAsyncAudioInterface(AsyncAudioInterface):
+    def __init__(self):
+        self.interrupt_count = 0
+
     async def start(self, input_callback):
         print("Async audio interface started")
         self.input_callback = input_callback
@@ -25,6 +28,7 @@ class MockAsyncAudioInterface(AsyncAudioInterface):
 
     async def interrupt(self):
         print("Async audio interrupted")
+        self.interrupt_count += 1
 
 
 # Add test constants and helpers at module level
@@ -465,3 +469,100 @@ async def test_async_websocket_url_construction_edge_cases():
         # Ensure no double slashes in the path (except after the protocol)
         url_path = conv_url.split("://", 1)[1]  # Remove protocol
         assert "//" not in url_path, f"Async conversation URL should not contain double slashes in path: {conv_url}"
+
+
+ASYNC_INTERRUPTION_MESSAGES = [
+    {
+        "type": "conversation_initiation_metadata",
+        "conversation_initiation_metadata_event": {"conversation_id": TEST_CONVERSATION_ID},
+    },
+    {
+        "type": "interruption",
+        "interruption_event": {"reason": "user_interrupted", "event_id": 1},
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_async_callback_interruption_invoked_with_audio_interface():
+    """callback_interruption fires with the raw event, alongside audio_interface.interrupt()."""
+    mock_ws = create_mock_async_websocket(ASYNC_INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = AsyncMock()
+    audio_interface = MockAsyncAudioInterface()
+
+    conversation = AsyncConversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=audio_interface,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.websockets.connect") as mock_connect:
+        mock_connect.return_value.__aenter__.return_value = mock_ws
+
+        await conversation.start_session()
+        await asyncio.sleep(0.1)
+
+        await conversation.end_session()
+        await conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    assert audio_interface.interrupt_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_callback_interruption_invoked_without_audio_interface():
+    """callback_interruption still fires in text-only mode (no audio_interface attached)."""
+    mock_ws = create_mock_async_websocket(ASYNC_INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = AsyncMock()
+
+    conversation = AsyncConversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=None,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.websockets.connect") as mock_connect:
+        mock_connect.return_value.__aenter__.return_value = mock_ws
+
+        await conversation.start_session()
+        await asyncio.sleep(0.1)
+
+        await conversation.end_session()
+        await conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+
+
+@pytest.mark.asyncio
+async def test_async_interruption_without_callback_does_not_raise():
+    """With callback_interruption left as the default None, interruption handling is unchanged."""
+    mock_ws = create_mock_async_websocket(ASYNC_INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    audio_interface = MockAsyncAudioInterface()
+
+    conversation = AsyncConversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=audio_interface,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.websockets.connect") as mock_connect:
+        mock_connect.return_value.__aenter__.return_value = mock_ws
+
+        await conversation.start_session()
+        await asyncio.sleep(0.1)
+
+        await conversation.end_session()
+        await conversation.wait_for_session_end()
+
+    assert audio_interface.interrupt_count == 1

--- a/tests/test_async_convai.py
+++ b/tests/test_async_convai.py
@@ -9,6 +9,7 @@ from elevenlabs.conversational_ai.conversation import (
     AsyncAudioInterface,
     AsyncConversation,
     ConversationInitiationData,
+    InterruptionEvent,
 )
 
 
@@ -509,7 +510,7 @@ async def test_async_callback_interruption_invoked_with_audio_interface():
         await conversation.end_session()
         await conversation.wait_for_session_end()
 
-    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason="user_interrupted"))
     assert audio_interface.interrupt_count == 1
 
 
@@ -538,7 +539,7 @@ async def test_async_callback_interruption_invoked_without_audio_interface():
         await conversation.end_session()
         await conversation.wait_for_session_end()
 
-    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason="user_interrupted"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -571,3 +571,41 @@ def test_interruption_without_callback_does_not_raise():
         conversation.wait_for_session_end()
 
     assert audio_interface.interrupt_count == 1
+
+
+def test_callback_interruption_defaults_reason_to_none():
+    """When the raw event has no 'reason' key, InterruptionEvent.reason falls back to None."""
+    mock_ws = create_mock_websocket(
+        [
+            {
+                "type": "conversation_initiation_metadata",
+                "conversation_initiation_metadata_event": {"conversation_id": TEST_CONVERSATION_ID},
+            },
+            {"type": "interruption", "interruption_event": {"event_id": 1}},
+        ]
+    )
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = MagicMock()
+
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=None,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.connect") as mock_connect:
+        mock_connect.return_value.__enter__.return_value = mock_ws
+        conversation.start_session()
+
+        timeout = 5
+        start_time = time.time()
+        while not interruption_callback.called and time.time() - start_time < timeout:
+            time.sleep(0.1)
+
+        conversation.end_session()
+        conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason=None))

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -4,6 +4,7 @@ from elevenlabs.conversational_ai.conversation import (
     AudioInterface,
     ConversationInitiationData,
     AgentChatResponsePartType,
+    InterruptionEvent,
 )
 import json
 import time
@@ -509,7 +510,7 @@ def test_callback_interruption_invoked_with_audio_interface():
         conversation.end_session()
         conversation.wait_for_session_end()
 
-    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason="user_interrupted"))
     assert audio_interface.interrupt_count == 1
 
 
@@ -540,7 +541,7 @@ def test_callback_interruption_invoked_without_audio_interface():
         conversation.end_session()
         conversation.wait_for_session_end()
 
-    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    interruption_callback.assert_called_once_with(InterruptionEvent(event_id=1, reason="user_interrupted"))
 
 
 def test_interruption_without_callback_does_not_raise():

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -9,6 +9,9 @@ import json
 import time
 
 class MockAudioInterface(AudioInterface):
+    def __init__(self):
+        self.interrupt_count = 0
+
     def start(self, input_callback):
         print("Audio interface started")
         self.input_callback = input_callback
@@ -21,6 +24,7 @@ class MockAudioInterface(AudioInterface):
 
     def interrupt(self):
         print("Audio interrupted")
+        self.interrupt_count += 1
 
 
 # Add test constants and helpers at module level
@@ -463,3 +467,106 @@ def test_text_only_mode_does_not_mutate_original_config():
     assert "text_only" not in original_override
     # The ConversationInitiationData object itself should also be unmodified
     assert "text_only" not in config.conversation_config_override
+
+
+INTERRUPTION_MESSAGES = [
+    {
+        "type": "conversation_initiation_metadata",
+        "conversation_initiation_metadata_event": {"conversation_id": TEST_CONVERSATION_ID},
+    },
+    {
+        "type": "interruption",
+        "interruption_event": {"reason": "user_interrupted", "event_id": 1},
+    },
+]
+
+
+def test_callback_interruption_invoked_with_audio_interface():
+    """callback_interruption fires with the raw event, alongside audio_interface.interrupt()."""
+    mock_ws = create_mock_websocket(INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = MagicMock()
+    audio_interface = MockAudioInterface()
+
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=audio_interface,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.connect") as mock_connect:
+        mock_connect.return_value.__enter__.return_value = mock_ws
+        conversation.start_session()
+
+        timeout = 5
+        start_time = time.time()
+        while not interruption_callback.called and time.time() - start_time < timeout:
+            time.sleep(0.1)
+
+        conversation.end_session()
+        conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+    assert audio_interface.interrupt_count == 1
+
+
+def test_callback_interruption_invoked_without_audio_interface():
+    """callback_interruption still fires in text-only mode (no audio_interface attached)."""
+    mock_ws = create_mock_websocket(INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    interruption_callback = MagicMock()
+
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=None,
+        callback_interruption=interruption_callback,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.connect") as mock_connect:
+        mock_connect.return_value.__enter__.return_value = mock_ws
+        conversation.start_session()
+
+        timeout = 5
+        start_time = time.time()
+        while not interruption_callback.called and time.time() - start_time < timeout:
+            time.sleep(0.1)
+
+        conversation.end_session()
+        conversation.wait_for_session_end()
+
+    interruption_callback.assert_called_once_with({"reason": "user_interrupted", "event_id": 1})
+
+
+def test_interruption_without_callback_does_not_raise():
+    """With callback_interruption left as the default None, interruption handling is unchanged."""
+    mock_ws = create_mock_websocket(INTERRUPTION_MESSAGES)
+    mock_client = MagicMock()
+    mock_client._client_wrapper.get_base_url.return_value = "https://api.elevenlabs.io"
+    audio_interface = MockAudioInterface()
+
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        audio_interface=audio_interface,
+    )
+
+    with patch("elevenlabs.conversational_ai.conversation.connect") as mock_connect:
+        mock_connect.return_value.__enter__.return_value = mock_ws
+        conversation.start_session()
+
+        timeout = 5
+        start_time = time.time()
+        while audio_interface.interrupt_count == 0 and time.time() - start_time < timeout:
+            time.sleep(0.1)
+
+        conversation.end_session()
+        conversation.wait_for_session_end()
+
+    assert audio_interface.interrupt_count == 1


### PR DESCRIPTION
## Issue

`Conversation` / `AsyncConversation` expose a callback for every WebSocket event type the wrapper dispatches — `agent_response`, `user_transcript`, `audio_alignment`, etc. — except `interruption`. When an interruption event arrived, the wrapper only called `audio_interface.interrupt()` internally; there was no way for a caller to observe the event, and text-only (no `audio_interface`) integrations couldn't observe it at all.

Closes #672.

## Fix

Added an optional `callback_interruption` parameter to both `Conversation` and `AsyncConversation`, following the same pattern already used for the other callbacks. It fires with a new `InterruptionEvent(event_id, reason)` dataclass (mirroring the existing `AudioEventAlignment` pattern) in addition to the existing `audio_interface.interrupt()` call, in both the sync and async paths.

Added test coverage for both paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional callback and additive dataclass; existing callers unchanged when the callback is omitted.
> 
> **Overview**
> Adds optional **`callback_interruption`** on sync **`Conversation`** and **`AsyncConversation`** so apps can observe WebSocket interruption events, including text-only sessions without an audio interface.
> 
> Introduces **`InterruptionEvent`** (`event_id`, optional `reason`) and wires interruption handling to still call **`audio_interface.interrupt()`** when present, then invoke the callback if set. Sync and async message paths share the same behavior.
> 
> Adds unit tests for callback invocation with/without audio, default `None` callback, and missing `reason` on the wire event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795971eca544e87f89fcc248105c4934ffa60f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->