### PR TITLE
Add a Telephony section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,77 @@ client_tools.register("calculate_sum", calculate_sum, is_async=False)
 client_tools.register("fetch_data", fetch_data, is_async=True)
 ```
 
+## Telephony
+
+ElevenAgents can answer and place phone calls. Twilio and Exotel numbers are imported with provider credentials; any other carrier — or your own PBX — connects over standard SIP trunking through the `sip_trunk` provider.
+
+### Importing a number over SIP trunking
+
+```python
+from elevenlabs.client import ElevenLabs
+from elevenlabs import (
+    InboundSipTrunkConfigRequestModel,
+    OutboundSipTrunkConfigRequestModel,
+    SipTrunkCredentialsRequestModel,
+)
+from elevenlabs.conversational_ai.phone_numbers import PhoneNumbersCreateRequestBody_SipTrunk
+
+elevenlabs = ElevenLabs(
+  api_key="YOUR_API_KEY",
+)
+
+phone_number = elevenlabs.conversational_ai.phone_numbers.create(
+    request=PhoneNumbersCreateRequestBody_SipTrunk(
+        phone_number="+442071234567",
+        label="Support line",
+        # Inbound: calls your carrier sends to ElevenLabs
+        inbound_trunk_config=InboundSipTrunkConfigRequestModel(
+            # ACL authentication — your carrier's signalling IPs, as addresses or CIDR blocks
+            allowed_addresses=["203.0.113.0/24"],
+            media_encryption="required",
+        ),
+        # Outbound: calls ElevenLabs sends to your carrier
+        outbound_trunk_config=OutboundSipTrunkConfigRequestModel(
+            address="sip.example-carrier.net",
+            transport="tls",
+            media_encryption="required",
+            # Digest authentication — omit to authenticate by source IP instead
+            credentials=SipTrunkCredentialsRequestModel(
+                username="YOUR_SIP_USERNAME",
+                password="YOUR_SIP_PASSWORD",
+            ),
+        ),
+    )
+)
+
+print(phone_number.phone_number_id)
+```
+
+`transport` accepts `auto`, `udp`, `tcp` or `tls`, and `media_encryption` accepts `disabled`, `allowed` or `required`. Pass `enabled_codecs=["G722/8000", "PCMA/8000"]` on the outbound config to restrict the codecs offered on outbound calls; when omitted, every supported codec is offered.
+
+Carriers differ in which of these they accept — Twilio, Telnyx, DIDWW and Vonage each document their own SIP hostnames, authentication modes and codec support — so read your provider's instructions alongside the [SIP trunking guide](https://elevenlabs.io/docs/eleven-agents/phone-numbers/sip-trunking) for the ElevenLabs side of the configuration.
+
+### Placing an outbound call
+
+```python
+call = elevenlabs.conversational_ai.sip_trunk.outbound_call(
+    agent_id="YOUR_AGENT_ID",
+    agent_phone_number_id=phone_number.phone_number_id,
+    to_number="+442079460000",
+)
+
+print(call.success, call.conversation_id, call.sip_call_id)
+```
+
+### Listing configured numbers
+
+```python
+for number in elevenlabs.conversational_ai.phone_numbers.list(provider="sip_trunk"):
+    print(number.phone_number_id, number.label, number.supports_outbound)
+```
+
+Every method above is also available on `AsyncElevenLabs` with the same signature.
+
 ## Speech Engine
 
 Speech Engine lets you build server-side voice agents that receive real-time transcripts from the ElevenLabs API and stream LLM responses back for text-to-speech synthesis. Your server acts as a WebSocket endpoint — ElevenLabs connects to it, sends user transcripts, and your code decides how to respond.


### PR DESCRIPTION
The README documents TTS, voices, streaming, ElevenAgents and Speech Engine, but not telephony — `grep -i "twilio\|exotel\|sip\|phone" README.md` returns nothing, even though `conversational_ai.phone_numbers` and `conversational_ai.sip_trunk` are both in the SDK.

`reference.md` lists the models, but it does not convey the two things that actually cost time when connecting a carrier:

- `inbound_trunk_config` and `outbound_trunk_config` correspond to the two call directions, and you generally want both.
- `allowed_addresses` (ACL) and `credentials` (digest) are alternative authentication modes, not two fields you have to fill in.

## What the section adds

It sits between `## ElevenAgents` and `## Speech Engine` and covers:

- **Importing a number over SIP trunking** — `phone_numbers.create` with `PhoneNumbersCreateRequestBody_SipTrunk`, both trunk configs, with comments marking which direction each one governs, plus the accepted `transport` / `media_encryption` / `enabled_codecs` values.
- **Placing an outbound call** — `sip_trunk.outbound_call`.
- **Listing configured numbers** — `phone_numbers.list(provider="sip_trunk")`.
- A closing note that the same methods exist on `AsyncElevenLabs`.

## Verification

Every claim was checked against the generated models offline — no API calls, so nothing here needs a key:

| Claim in the section | How it was checked |
| --- | --- |
| The imports as written | executed verbatim |
| The request body as written | constructed; `provider` resolves to `sip_trunk` |
| `create(request=...)` | `inspect.signature` → `['request', 'request_options']` |
| `outbound_call(agent_id, agent_phone_number_id, to_number)` | `inspect.signature` |
| `list(provider="sip_trunk")` | `TelephonyProvider` → `twilio`, `sip_trunk`, `exotel` |
| `phone_number.phone_number_id` | field on `CreatePhoneNumberResponseModel` |
| `call.success`, `.conversation_id`, `.sip_call_id` | fields on `SipTrunkOutboundCallResponse` |
| `number.phone_number_id`, `.label`, `.supports_outbound` | fields on `PhoneNumbersListResponseItem_SipTrunk` |
| `transport` accepts `auto`/`udp`/`tcp`/`tls` | literal args of the annotation |
| `media_encryption` accepts `disabled`/`allowed`/`required` | literal args of the annotation |
| `enabled_codecs=[...]` | constructed on the outbound config |
| "also available on `AsyncElevenLabs`" | all three are coroutine functions there |
| ACL without credentials is valid | inbound config constructed with `allowed_addresses` only |

## Notes

Happy to trim or restructure. One paragraph names carriers — Twilio, Telnyx, DIDWW and Vonage — purely to say that each documents its own hostnames, authentication mode and codecs; drop the names if you would rather the README not list providers.

Disclosure: I work at DIDWW, one of the carriers named there. The section is not about DIDWW and the SDK needs no DIDWW-specific code — any carrier connects through the generic `sip_trunk` provider, which is precisely the point the README was missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or API behavior impact.
> 
> **Overview**
> Adds a **Telephony** section to the README between **ElevenAgents** and **Speech Engine**, documenting conversational AI phone/SIP capabilities that were previously absent from the user-facing guide.
> 
> The section explains how Twilio/Exotel import differs from generic **`sip_trunk`** carriers, then walks through **`phone_numbers.create`** with **`PhoneNumbersCreateRequestBody_SipTrunk`**, separating **inbound** vs **outbound** trunk config and clarifying **ACL** (`allowed_addresses`) vs **digest** (`credentials`) as alternative auth modes. It documents accepted **`transport`**, **`media_encryption`**, and optional **`enabled_codecs`**, links to the SIP trunking guide, and includes examples for **`sip_trunk.outbound_call`** and **`phone_numbers.list(provider="sip_trunk")`**, plus a note that the same APIs exist on **`AsyncElevenLabs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d481d64601e72edd624f67f393fcb485c032b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->