### PR TITLE
fix: send complete Accept header in SSE client

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -13,6 +13,7 @@ src/elevenlabs/url_utils.py
 src/elevenlabs/realtime/
 src/elevenlabs/speech_engine/
 src/elevenlabs/speech_engine_custom.py
+src/elevenlabs/core/http_sse/
 
 # Ignore CI files
 .github/

--- a/docs/residual-review-findings/fix-671-sse-accept-header.md
+++ b/docs/residual-review-findings/fix-671-sse-accept-header.md
@@ -1,0 +1,6 @@
+## Residual Review Findings
+
+- P2 — `src/elevenlabs/core/http_sse/_api.py:93` — Broadened Accept header breaks strict servers, invites JSON responses — filed as [elevenlabs-python#847](https://github.com/elevenlabs/elevenlabs-python/issues/847)
+- P2 — `src/elevenlabs/core/http_sse/_api.py:93` — Broadened Accept header breaks strict servers, invites JSON responses — settled_conflict with KTD-1 (session-settled, user-approved: send combined `application/json, text/event-stream`; caller-supplied Accept overwrite is an explicit non-goal). Preference-grade alternative (`headers.setdefault(...)`), routed advisory/human, report-only — not applied.
+
+Source run context: ce-code-review run 20260815-232345-90a6cd57 on branch fix/671-sse-accept-header (base origin/main ea95897, head 584ae39), review of fix for issue #671 (SSE Accept header). Reviewers: correctness, project-standards, testing, adversarial (in-process fallback; cross-model peer not started — host un-attestable).

--- a/src/elevenlabs/core/http_sse/_api.py
+++ b/src/elevenlabs/core/http_sse/_api.py
@@ -90,7 +90,7 @@ class EventSource:
 @contextmanager
 def connect_sse(client: httpx.Client, method: str, url: str, **kwargs: Any) -> Iterator[EventSource]:
     headers = kwargs.pop("headers", {})
-    headers["Accept"] = "text/event-stream"
+    headers["Accept"] = "application/json, text/event-stream"
     headers["Cache-Control"] = "no-store"
 
     with client.stream(method, url, headers=headers, **kwargs) as response:
@@ -105,7 +105,7 @@ async def aconnect_sse(
     **kwargs: Any,
 ) -> AsyncIterator[EventSource]:
     headers = kwargs.pop("headers", {})
-    headers["Accept"] = "text/event-stream"
+    headers["Accept"] = "application/json, text/event-stream"
     headers["Cache-Control"] = "no-store"
 
     async with client.stream(method, url, headers=headers, **kwargs) as response:

--- a/tests/test_http_sse.py
+++ b/tests/test_http_sse.py
@@ -113,3 +113,38 @@ async def test_aconnect_sse_accept_header(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert captured["headers"]["Accept"] == "application/json, text/event-stream"
     assert [event.data for event in events] == ["hello"]
+
+
+async def test_aconnect_sse_preserves_other_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: typing.Dict[str, typing.Any] = {}
+
+    class FakeStream(_AsyncFakeStream):
+        def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+            super().__init__(method, url, headers=headers, **kwargs)
+            captured["headers"] = headers
+
+    monkeypatch.setattr(httpx.AsyncClient, "stream", FakeStream)
+
+    client = httpx.AsyncClient()
+    async with aconnect_sse(client, "GET", "https://example.com/events", headers={"X-Custom": "v"}) as es:
+        list([event async for event in es.aiter_sse()])
+
+    assert captured["headers"]["X-Custom"] == "v"
+    assert captured["headers"]["Cache-Control"] == "no-store"
+    assert captured["headers"]["Accept"] == "application/json, text/event-stream"
+
+
+async def test_aconnect_sse_rejects_non_sse_content_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse(_AsyncFakeResponse):
+        headers = {"content-type": "application/json"}
+
+    class FakeStream(_AsyncFakeStream):
+        async def __aenter__(self) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx.AsyncClient, "stream", FakeStream)
+
+    client = httpx.AsyncClient()
+    async with aconnect_sse(client, "GET", "https://example.com/events") as es:
+        with pytest.raises(SSEError):
+            list([event async for event in es.aiter_sse()])

--- a/tests/test_http_sse.py
+++ b/tests/test_http_sse.py
@@ -1,0 +1,115 @@
+import typing
+
+import httpx
+import pytest
+import typing_extensions
+
+from elevenlabs.core.http_sse import aconnect_sse, connect_sse
+from elevenlabs.core.http_sse._exceptions import SSEError
+
+
+class _SyncFakeResponse:
+    headers = {"content-type": "text/event-stream"}
+
+    def iter_bytes(self) -> typing.Iterator[bytes]:
+        return iter([b"data: hello\n\n"])
+
+
+class _AsyncFakeResponse:
+    headers = {"content-type": "text/event-stream"}
+
+    async def aiter_lines(self) -> typing.AsyncIterator[str]:
+        yield "data: hello\n"
+        yield "\n"
+
+
+class _SyncFakeStream:
+    def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+        self._headers = headers
+
+    def __enter__(self) -> _SyncFakeResponse:
+        return _SyncFakeResponse()
+
+    def __exit__(self, exc_type: typing.Any, exc: typing.Any, tb: typing.Any) -> typing_extensions.Literal[False]:
+        return False
+
+
+class _AsyncFakeStream:
+    def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+        self._headers = headers
+
+    async def __aenter__(self) -> _AsyncFakeResponse:
+        return _AsyncFakeResponse()
+
+    async def __aexit__(self, exc_type: typing.Any, exc: typing.Any, tb: typing.Any) -> bool:
+        return False
+
+
+def test_connect_sse_accept_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: typing.Dict[str, typing.Any] = {}
+
+    class FakeStream(_SyncFakeStream):
+        def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+            super().__init__(method, url, headers=headers, **kwargs)
+            captured["headers"] = headers
+
+    monkeypatch.setattr(httpx.Client, "stream", FakeStream)
+
+    client = httpx.Client()
+    with connect_sse(client, "GET", "https://example.com/events") as es:
+        events = list(es.iter_sse())
+
+    assert captured["headers"]["Accept"] == "application/json, text/event-stream"
+    assert [event.data for event in events] == ["hello"]
+
+
+def test_connect_sse_preserves_other_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: typing.Dict[str, typing.Any] = {}
+
+    class FakeStream(_SyncFakeStream):
+        def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+            super().__init__(method, url, headers=headers, **kwargs)
+            captured["headers"] = headers
+
+    monkeypatch.setattr(httpx.Client, "stream", FakeStream)
+
+    client = httpx.Client()
+    with connect_sse(client, "GET", "https://example.com/events", headers={"X-Custom": "v"}) as es:
+        list(es.iter_sse())
+
+    assert captured["headers"]["X-Custom"] == "v"
+    assert captured["headers"]["Cache-Control"] == "no-store"
+
+
+def test_connect_sse_rejects_non_sse_content_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse(_SyncFakeResponse):
+        headers = {"content-type": "application/json"}
+
+    class FakeStream(_SyncFakeStream):
+        def __enter__(self) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx.Client, "stream", FakeStream)
+
+    client = httpx.Client()
+    with connect_sse(client, "GET", "https://example.com/events") as es:
+        with pytest.raises(SSEError):
+            list(es.iter_sse())
+
+
+async def test_aconnect_sse_accept_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: typing.Dict[str, typing.Any] = {}
+
+    class FakeStream(_AsyncFakeStream):
+        def __init__(self, method: str, url: str, headers: typing.Optional[typing.Dict[str, str]] = None, **kwargs: typing.Any):
+            super().__init__(method, url, headers=headers, **kwargs)
+            captured["headers"] = headers
+
+    monkeypatch.setattr(httpx.AsyncClient, "stream", FakeStream)
+
+    client = httpx.AsyncClient()
+    async with aconnect_sse(client, "GET", "https://example.com/events") as es:
+        events = [event async for event in es.aiter_sse()]
+
+    assert captured["headers"]["Accept"] == "application/json, text/event-stream"
+    assert [event.data for event in events] == ["hello"]


### PR DESCRIPTION
## Summary

SSE connections from `connect_sse` and `aconnect_sse` now send `Accept: application/json, text/event-stream` instead of `Accept: text/event-stream`. Servers that validate the Accept header (e.g. Composio MCP, issue #671) previously rejected the request with 406. `text/event-stream` is retained, so strict SSE servers keep working.

The hand-edited Fern-generated module is protected from regeneration via `.fernignore`, and regression tests cover the sync and async paths, header preservation, and the response content-type guard.

Fixes #671

## Test plan

- `pytest tests/test_http_sse.py` - 6 new tests pass.
- Full suite: 190 passed. Remaining failures are pre-existing API-key/network tests requiring `ELEVENLABS_API_KEY` (CI provides it).
- `ruff` and `mypy` clean on changed files.

Session-settled decisions carried from planning: the combined Accept header value (user-approved); no Compound Engineering branding on this PR (user-directed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow HTTP client header change with existing content-type validation; residual risk of strict servers preferring JSON is documented separately (#847).
> 
> **Overview**
> Fixes **406 rejections** from gateways that require `Accept` to include `application/json` (e.g. Composio MCP, #671) by changing `connect_sse` and `aconnect_sse` to send **`Accept: application/json, text/event-stream`** instead of only `text/event-stream`.
> 
> **`src/elevenlabs/core/http_sse/`** is added to **`.fernignore`** so this hand-edited module is not overwritten on Fern regen. **`tests/test_http_sse.py`** adds six regression tests (sync/async Accept value, custom header preservation, and `SSEError` when the response is not `text/event-stream`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab802dbf1c37c21c7c767e7981c14b650f742480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->