### PR TITLE
Add file_ids to send_multimodal_message

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -88,23 +88,26 @@ class MultimodalMessageFile:
 
 
 class MultimodalMessageClientToOrchestratorEvent:
-    """Event for sending multimodal messages combining text and a file reference."""
+    """Event for sending multimodal messages combining text and file references."""
 
     def __init__(
         self,
         text: Optional[str] = None,
         file_id: Optional[str] = None,
+        file_ids: Optional[List[str]] = None,
     ):
         self.type: Literal[ClientToOrchestratorEvent.MULTIMODAL_MESSAGE] = ClientToOrchestratorEvent.MULTIMODAL_MESSAGE
         self.text = text
-        self.file_id = file_id
+        self.file_ids = list(file_ids) if file_ids else ([file_id] if file_id else [])
 
     def to_dict(self) -> dict:
         result: Dict[str, Any] = {"type": self.type}
         if self.text:
             result["text"] = UserMessageClientToOrchestratorEvent(text=self.text).to_dict()
-        if self.file_id:
-            result["file"] = MultimodalMessageFile(file_id=self.file_id).to_dict()
+        if self.file_ids:
+            files = [MultimodalMessageFile(file_id=fid).to_dict() for fid in self.file_ids]
+            result["file"] = files[0]
+            result["files"] = files
         return result
 
 
@@ -889,23 +892,25 @@ class Conversation(BaseConversation):
         self,
         text: Optional[str] = None,
         file_id: Optional[str] = None,
+        file_ids: Optional[List[str]] = None,
     ):
-        """Send a multimodal message combining text and/or a file reference.
+        """Send a multimodal message combining text and/or file references.
 
         Args:
             text: Optional text message to include.
-            file_id: Optional file ID to include (must be a previously uploaded file).
+            file_id: Deprecated: use file_ids.
+            file_ids: Optional file IDs to include (must be previously uploaded files).
 
         Raises:
             RuntimeError: If the session is not active or websocket is not connected.
-            ValueError: If neither text nor file_id is provided.
+            ValueError: If none of text, file_id, or file_ids is provided.
         """
         if not self._ws:
             raise RuntimeError("Session not started or websocket not connected.")
-        if not text and not file_id:
-            raise ValueError("At least one of text or file_id must be provided.")
+        if not text and not file_id and not file_ids:
+            raise ValueError("At least one of text, file_id, or file_ids must be provided.")
 
-        event = MultimodalMessageClientToOrchestratorEvent(text=text, file_id=file_id)
+        event = MultimodalMessageClientToOrchestratorEvent(text=text, file_id=file_id, file_ids=file_ids)
         try:
             self._ws.send(json.dumps(event.to_dict()))
         except Exception as e:
@@ -1193,23 +1198,25 @@ class AsyncConversation(BaseConversation):
         self,
         text: Optional[str] = None,
         file_id: Optional[str] = None,
+        file_ids: Optional[List[str]] = None,
     ):
-        """Send a multimodal message combining text and/or a file reference.
+        """Send a multimodal message combining text and/or file references.
 
         Args:
             text: Optional text message to include.
-            file_id: Optional file ID to include (must be a previously uploaded file).
+            file_id: Deprecated: use file_ids.
+            file_ids: Optional file IDs to include (must be previously uploaded files).
 
         Raises:
             RuntimeError: If the session is not active or websocket is not connected.
-            ValueError: If neither text nor file_id is provided.
+            ValueError: If none of text, file_id, or file_ids is provided.
         """
         if not self._ws:
             raise RuntimeError("Session not started or websocket not connected.")
-        if not text and not file_id:
-            raise ValueError("At least one of text or file_id must be provided.")
+        if not text and not file_id and not file_ids:
+            raise ValueError("At least one of text, file_id, or file_ids must be provided.")
 
-        event = MultimodalMessageClientToOrchestratorEvent(text=text, file_id=file_id)
+        event = MultimodalMessageClientToOrchestratorEvent(text=text, file_id=file_id, file_ids=file_ids)
         try:
             await self._ws.send(json.dumps(event.to_dict()))
         except Exception as e:

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -4,6 +4,7 @@ from elevenlabs.conversational_ai.conversation import (
     AudioInterface,
     ConversationInitiationData,
     AgentChatResponsePartType,
+    MultimodalMessageClientToOrchestratorEvent,
 )
 import json
 import time
@@ -463,3 +464,33 @@ def test_text_only_mode_does_not_mutate_original_config():
     assert "text_only" not in original_override
     # The ConversationInitiationData object itself should also be unmodified
     assert "text_only" not in config.conversation_config_override
+
+
+def test_multimodal_message_file_id_dual_sends_file_and_files():
+    event = MultimodalMessageClientToOrchestratorEvent(text="hello", file_id="file_a")
+    assert event.to_dict() == {
+        "type": "multimodal_message",
+        "text": {"type": "user_message", "text": "hello"},
+        "file": {"type": "file_input", "file_id": "file_a"},
+        "files": [{"type": "file_input", "file_id": "file_a"}],
+    }
+
+
+def test_multimodal_message_file_ids_wins_and_dual_sends():
+    event = MultimodalMessageClientToOrchestratorEvent(file_id="ignored", file_ids=["file_a", "file_b"])
+    assert event.to_dict() == {
+        "type": "multimodal_message",
+        "file": {"type": "file_input", "file_id": "file_a"},
+        "files": [
+            {"type": "file_input", "file_id": "file_a"},
+            {"type": "file_input", "file_id": "file_b"},
+        ],
+    }
+
+
+def test_multimodal_message_text_only_omits_file_fields():
+    event = MultimodalMessageClientToOrchestratorEvent(text="hello")
+    assert event.to_dict() == {
+        "type": "multimodal_message",
+        "text": {"type": "user_message", "text": "hello"},
+    }


### PR DESCRIPTION
## Summary
- Add `file_ids` beside the existing `file_id` on `send_multimodal_message` (plural wins).
- Dual-send `file` + `files` on the wire so older backends still receive the first attachment.
- Mark `file_id` as deprecated. Do not delete it.

Written by Cursor Grok 4.6, using Cursor

## Test plan
- [x] `to_dict()` unit tests for singular, plural, and text-only
- [ ] CI on this PR
- [ ] Confirm an old backend still accepts a payload with both `file` and `files`