### PR TITLE
Honor user_id set on ConversationInitiationData

### DIFF
--- a/src/elevenlabs/conversational_ai/conversation.py
+++ b/src/elevenlabs/conversational_ai/conversation.py
@@ -554,6 +554,9 @@ class BaseConversation:
         return json.dumps(message)
 
     def _create_initiation_message(self):
+        # The top-level user_id takes precedence, but fall back to the one set on
+        # ConversationInitiationData so it is honored like its sibling config fields.
+        user_id = self.user_id or self.config.user_id
         return json.dumps(
             {
                 "type": "conversation_initiation_client_data",
@@ -564,7 +567,7 @@ class BaseConversation:
                     "source": "python_sdk",
                     "version": __version__,
                 },
-                **({"user_id": self.user_id} if self.user_id else {}),
+                **({"user_id": user_id} if user_id else {}),
             }
         )
 

--- a/tests/test_convai.py
+++ b/tests/test_convai.py
@@ -494,3 +494,35 @@ def test_multimodal_message_text_only_omits_file_fields():
         "type": "multimodal_message",
         "text": {"type": "user_message", "text": "hello"},
     }
+
+
+def test_user_id_from_conversation_initiation_data():
+    # user_id set on ConversationInitiationData should reach the initiation message,
+    # like its sibling fields (extra_body, conversation_config_override, dynamic_variables).
+    mock_client = MagicMock()
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        requires_auth=False,
+        config=ConversationInitiationData(user_id="config_user_456"),
+    )
+    conversation.client_tools.stop()
+
+    init_message = json.loads(conversation._create_initiation_message())
+    assert init_message["user_id"] == "config_user_456"
+
+
+def test_user_id_top_level_takes_precedence_over_config():
+    # The top-level user_id wins when both are provided.
+    mock_client = MagicMock()
+    conversation = Conversation(
+        client=mock_client,
+        agent_id=TEST_AGENT_ID,
+        user_id="top_level_user",
+        requires_auth=False,
+        config=ConversationInitiationData(user_id="config_user_456"),
+    )
+    conversation.client_tools.stop()
+
+    init_message = json.loads(conversation._create_initiation_message())
+    assert init_message["user_id"] == "top_level_user"


### PR DESCRIPTION
`ConversationInitiationData` exposes a `user_id` field alongside `extra_body`, `conversation_config_override` and `dynamic_variables`, but `_create_initiation_message` only reads the top-level `Conversation(user_id=...)` argument. A `user_id` set on the config object is stored and then dropped, so it never reaches the server in the `conversation_initiation_client_data` payload.

This falls back to the config value while keeping the top-level argument as the winner when both are set, so it matches how the other three config fields are already handled and preserves the top-level precedence from #720.

```python
user_id = self.user_id or self.config.user_id
```

Added two tests: one for the config path, one for the precedence.
