### PR TITLE
Fix realtime send() docstring examples to use audio_base_64

### DIFF
--- a/src/elevenlabs/realtime/connection.py
+++ b/src/elevenlabs/realtime/connection.py
@@ -57,7 +57,7 @@ class RealtimeConnection:
         connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, lambda data: print(data))
 
         # Send audio
-        connection.send({"audioBase64": audio_chunk})
+        connection.send({"audio_base_64": audio_chunk})
 
         # When done
         connection.commit()
@@ -204,7 +204,7 @@ class RealtimeConnection:
             ```python
             # Send all audio chunks
             for chunk in audio_chunks:
-                connection.send({"audioBase64": chunk})
+                connection.send({"audio_base_64": chunk})
 
             # Commit the audio segment
             await connection.commit()


### PR DESCRIPTION
The class-level docstring and the `commit()` example both call `connection.send({"audioBase64": ...})`, but `send()` reads `data.get("audio_base_64", "")`. Copying either example silently sends an empty string, so no audio is transcribed and no error is raised.

This aligns both examples with the snake_case `audio_base_64` key that `send()`'s own docstring already documents. Docs only, no code change.
