### PR TITLE
Stop the OMIT sentinel from reaching the realtime TTS connection

### DIFF
--- a/src/elevenlabs/realtime_tts.py
+++ b/src/elevenlabs/realtime_tts.py
@@ -92,11 +92,17 @@ class RealtimeTextToSpeechClient(TextToSpeechClient):
             ),
         )
         """
+        # OMIT is a sentinel meaning "not supplied", so it must never reach the wire
+        if model_id is OMIT:
+            model_id = None
+        if voice_settings is OMIT:
+            voice_settings = None
+
         with connect(
             build_ws_url(
                 self._ws_base_url,
                 ["v1", "text-to-speech", voice_id, "stream-input"],
-                {"model_id": model_id, "output_format": output_format},
+                remove_none_from_dict({"model_id": model_id, "output_format": output_format}),
             ),
             additional_headers=jsonable_encoder(
                 remove_none_from_dict(

--- a/tests/test_realtime_tts_params.py
+++ b/tests/test_realtime_tts_params.py
@@ -1,0 +1,67 @@
+"""convert_realtime must not leak the OMIT sentinel into the URL or the first frame."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+from elevenlabs.realtime_tts import RealtimeTextToSpeechClient
+from elevenlabs.types.voice_settings import VoiceSettings
+
+AUDIO = b"audio chunk"
+
+
+def _run(**kwargs):
+    """Drive convert_realtime to its first yield, returning the URL, the frames sent, and that chunk."""
+    captured = {}
+    socket = MagicMock()
+    socket.__enter__.return_value = socket
+    socket.recv.return_value = json.dumps({"audio": base64.b64encode(AUDIO).decode()})
+
+    def connect(url, **_):
+        captured["url"] = url
+        return socket
+
+    client = object.__new__(RealtimeTextToSpeechClient)
+    client._client_wrapper = MagicMock()
+    client._client_wrapper.get_headers.return_value = {}
+    client._ws_base_url = "wss://api.elevenlabs.io"
+
+    with patch("elevenlabs.realtime_tts.connect", connect):
+        stream = client.convert_realtime("VOICE", text=iter(["hello there."]), **kwargs)
+        chunk = next(stream)
+        stream.close()
+
+    frames = [json.loads(call.args[0]) for call in socket.send.call_args_list]
+    return captured["url"], frames, chunk
+
+
+def test_omitted_model_id_is_not_sent():
+    url, _, chunk = _run()
+    assert "model_id" not in url, "OMIT sentinel leaked into the URL: {}".format(url)
+    assert chunk == AUDIO
+
+
+def test_omitted_voice_settings_serialize_to_null():
+    _, frames, _ = _run()
+    assert frames[0]["voice_settings"] is None
+
+
+def test_explicit_model_id_is_sent():
+    url, _, _ = _run(model_id="eleven_flash_v2_5")
+    assert "model_id=eleven_flash_v2_5" in url
+
+
+def test_explicit_voice_settings_are_sent():
+    _, frames, _ = _run(voice_settings=VoiceSettings(stability=0.5, similarity_boost=0.75))
+    assert frames[0]["voice_settings"]["stability"] == 0.5
+
+
+def test_output_format_still_sent():
+    url, _, _ = _run()
+    assert "output_format=mp3_44100_128" in url
+
+
+def test_omitted_model_id_with_explicit_voice_settings():
+    """The URL defect on its own: voice_settings supplied, so nothing else fails first."""
+    url, _, _ = _run(voice_settings=VoiceSettings(stability=0.5, similarity_boost=0.75))
+    assert "model_id" not in url, "OMIT sentinel leaked into the URL: {}".format(url)


### PR DESCRIPTION
`convert_realtime` raises `AttributeError: 'ellipsis' object has no attribute 'dict'` at its documented default, before it sends any text. `model_id` and `voice_settings` both default to `OMIT`, which is `Ellipsis`. Line 115 is `voice_settings.dict() if voice_settings else None`, and `Ellipsis` is truthy, so `.dict()` is called on the sentinel.

The same sentinel reaches the URL. `model_id` goes straight into `build_ws_url`, where `urlencode` stringifies it, so a caller who passes `voice_settings` but omits `model_id` connects to `stream-input?model_id=Ellipsis&output_format=mp3_44100_128` instead of letting the server apply its default. This predates the `build_ws_url` refactor in #780; the old f-string produced the same query string.

`realtime/scribe.py` and `conversational_ai/conversation.py` both build their params conditionally. This does the same, reusing the `remove_none_from_dict` already imported in this file.

Four of the six added tests fail on `main`. The suite goes from 189 to 195 passed, with the same 16 live-API failures on either side, and `mypy` is clean. Both files touched are listed in `.fernignore`. I left the pre-existing `ruff` import-order warning in this file alone rather than bury a six line fix.
